### PR TITLE
ci: update pre-commit-sweeper.sh for gha support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,9 +28,9 @@ jobs:
           pip install pre-commit
           pre-commit install
 
-      # Update doc if its a renovate PR
-      - name: Update doc
-        run: module-assets/ci/doc-sweeper.sh
+      # Check for pre-commit updates if it is a renovate PR
+      - name: Pre-commit sweeper
+        run: module-assets/ci/pre-commit-sweeper.sh
 
       # run pre-commit against all files
       - name: Pre-commit

--- a/module-assets/Makefile
+++ b/module-assets/Makefile
@@ -127,14 +127,17 @@ run-go-module-tests:
 		${DOCKER_REGISTRY}/$(IMAGE) \
 		bash -c "go test ./... -count=1 -v -timeout 5m"
 
-doc-sweeper:
-# Only used in Travis if needed in GH Actions just run ci/doc-sweeper.sh directly
+# TODO: Remove this command once all travis files have beeb migrated to use make pre-commit-sweeper (https://github.ibm.com/GoldenEye/issues/issues/1850)
+doc-sweeper: pre-commit-sweeper
+
+pre-commit-sweeper:
 	@if [ -z "$${TF_VAR_ibmcloud_api_key}" ]; then echo "Error: TF_VAR_ibmcloud_api_key is undefined"; exit 1; fi
 	@if [ -z "$${GH_TOKEN}" ]; then echo "Error: GH_TOKEN is undefined"; exit 1; fi
 	# Not directly mounting ~/.ssh because we will be changing the permissions, so creating backup and mounting that.
 	cp -r ~/.ssh /tmp
 	docker run -it -v $$(pwd):/mnt \
 		-v /tmp/.ssh:/root/.ssh \
+		-e TRAVIS \
 		-e TRAVIS_PULL_REQUEST \
 		-e TRAVIS_PULL_REQUEST_BRANCH \
 		-e TF_VAR_ibmcloud_api_key \
@@ -143,7 +146,7 @@ doc-sweeper:
 		bash -c "chown -R root /root/.ssh && \
 			chgrp -R root /root/.ssh && \
 			make ghe-netrc && \
-			ci/doc-sweeper.sh"
+			ci/pre-commit-sweeper.sh"
 	# Cleanup after (must use sudo as dir now owned by root)
 	sudo rm -rf /tmp/.ssh
 

--- a/module-assets/ci/pre-commit-sweeper.sh
+++ b/module-assets/ci/pre-commit-sweeper.sh
@@ -1,7 +1,7 @@
 #! /bin/bash
 
-# This script is designed to run as part of CI on PRs opened by renovate.
-# The script will run the pre-commit hook and if there are any doc changes detected, it will commit them to the PR
+# This script is designed to run as part of Travis or Github Actions on PRs opened by renovate.
+# The script will run the pre-commit hook and if there are any changes detected, it will commit them to the PR
 # branch which will trigger a new run of the pipeline.
 
 set -e
@@ -19,21 +19,37 @@ function git_push() {
   git commit -m "doc: committing files modified by the hook"
   git push origin "${TRAVIS_PULL_REQUEST_BRANCH}"
 }
-# When running in Github Actions Set the environment variables with the following syntax
-#   env:
-#      TRAVIS_PULL_REQUEST_BRANCH: ${{ github.head_ref }}
-#      TRAVIS_PULL_REQUEST: ${{ github.event.number }}
+
+# Determine if PR
+IS_PR=false
+if [ "${GITHUB_ACTIONS}" == "true" ]; then
+  # GITHUB_HEAD_REF: This property is only set when the event that triggers a workflow run is either pull_request or pull_request_target
+  if [ -n "${GITHUB_HEAD_REF}" ]; then
+    IS_PR=true
+    BRANCH="${GITHUB_HEAD_REF}"
+  fi
+elif [ "${TRAVIS}" == "true" ]; then
+  # TRAVIS_PULL_REQUEST: The pull request number if the current job is a pull request, “false” if it’s not a pull request.
+  if [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
+    IS_PR=true
+    BRANCH="${TRAVIS_PULL_REQUEST_BRANCH}"
+  fi
+else
+  echo "Could not determine CI runtime environment. Script only support travis or github actions."
+  exit 1
+fi
+
 # Only run on PRs created by renovate
-if [[ "${TRAVIS_PULL_REQUEST}" != "false" ]] && [[ "${TRAVIS_PULL_REQUEST_BRANCH}" =~ "renovate" ]]; then
+if [[ ${IS_PR} == true ]] && [[ "${BRANCH}" =~ "renovate" ]]; then
   if ! pre-commit run --all-files; then
     echo "Pre-commit did not return 0 exit code. Checking if any files changes.."
     # Check if hook modified any files
     if ! git diff --exit-code; then
-      echo "Detected file changes - configuring git to push changes to branch: ${TRAVIS_PULL_REQUEST_BRANCH}"
+      echo "Detected file changes - configuring git to push changes to branch: ${BRANCH}"
       # Configure local git
       git_config
       # Checkout to PR branch
-      git checkout "${TRAVIS_PULL_REQUEST_BRANCH}"
+      git checkout "${BRANCH}"
       # Commit and push changes
       git_push
       echo "Changes pushed in a new commit, exiting with exit code 1 - new commit will trigger new pipeline run"


### PR DESCRIPTION
- Renamed `doc-sweeper.sh` to `pre-commit-sweeper.sh` because the script not only updates terradocs, it also manages updating the detect secrets version in the baseline if that has changed in a new version of the common pre-commit yaml
- Added support to the script for running in a github actions runtime (https://github.ibm.com/GoldenEye/issues/issues/1848)