### PR TITLE
ci: rename GHA job to CI_Pipeline

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ on:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  CI_PIPELINE:
+  CI_Pipeline:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Keeping consistent with other pipelines