### PR TITLE
fix: added exclusions for pre-commit yaml check

### DIFF
--- a/module-assets/.pre-commit-config.yaml
+++ b/module-assets/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
   rev: v4.3.0
   hooks:
     - id: check-yaml
-      exclude: chart/
+      exclude: chart/|metadata.yaml
     - id: end-of-file-fixer
     - id: trailing-whitespace
     - id: check-merge-conflict


### PR DESCRIPTION
Added some exclusions for the pre-commit yaml check in order to temporarily allow full pre-commit to work with existing files.
