### PR TITLE
ci(renovate): set automerge to false

### DIFF
--- a/commonRenovateConfig.json
+++ b/commonRenovateConfig.json
@@ -6,7 +6,7 @@
   ],
   "cloneSubmodules": false,
   "prConcurrentLimit": 1,
-  "automerge": true,
+  "automerge": false,
   "force": {
     "recreateClosed": true
   },


### PR DESCRIPTION
The renovate pipeline is spitting errors like this:

```
"response": {
           "statusCode": 405,
           "statusMessage": "Method Not Allowed",
           "body": {
             "message": "At least 1 approving review is required by reviewers with write access.",
             "documentation_url": "https://docs.github.com/articles/about-protected-branches"
           },
```

Solution: disable auto merge in the common renovate config file. We have our own auto approve / merge script that we can roll out when we are comfortable with auto merging renovate PRs on the `terraform-ibm-modules` org