### PR TITLE
ci: set branchConcurrentLimit to 0 (no limit)

### DIFF
--- a/commonRenovateConfig.json
+++ b/commonRenovateConfig.json
@@ -6,6 +6,7 @@
   ],
   "cloneSubmodules": false,
   "prConcurrentLimit": 1,
+  "branchConcurrentLimit": 0,
   "automerge": false,
   "force": {
     "description": "Recreate PRs even if same ones were closed previously",


### PR DESCRIPTION
PR to set [branchConcurrentLimit](https://docs.renovatebot.com/configuration-options/#branchconcurrentlimit) to 0 (no limit).

Why? See https://github.com/renovatebot/renovate/discussions/16426