### PR TITLE
ci: add .one-pipeline.yaml to the skip tests array

### DIFF
--- a/module-assets/ci/run-tests.sh
+++ b/module-assets/ci/run-tests.sh
@@ -56,7 +56,8 @@ if [ ${IS_PR} == true ]; then
                          "common-dev-assets"
                          "Makefile"
                          "renovate.json"
-                         "catalogValidationValues.json.template")
+                         "catalogValidationValues.json.template"
+                         ".one-pipeline.yaml")
 
   # Determine all files being changed in the PR, and add it to array
   changed_files="$(git diff --name-only "${TARGET_BRANCH}..HEAD" --)"


### PR DESCRIPTION
We don't need to run tests if a PR only contains updates to `.one-pipeline.yaml` just like we already have for `.travis.yml`