### PR TITLE
Revert "chore(deps): update pre-commit hook antonbabenko/pre-commit-terraform to v1.74.0"

### DIFF
--- a/module-assets/.pre-commit-config.yaml
+++ b/module-assets/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
       stages: [commit-msg]
       additional_dependencies: ['@commitlint/config-angular']
 - repo: https://github.com/antonbabenko/pre-commit-terraform
-  rev: v1.74.0
+  rev: v1.73.0
   hooks:
     - id: terraform_fmt
     - id: terraform_validate

--- a/module-assets/basic-pre-commit/.pre-commit-config.yaml
+++ b/module-assets/basic-pre-commit/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
       stages: [commit-msg]
       additional_dependencies: ['@commitlint/config-angular']
 - repo: https://github.com/antonbabenko/pre-commit-terraform
-  rev: v1.74.0
+  rev: v1.73.0
   hooks:
     - id: terraform_fmt
     - id: terraform_docs


### PR DESCRIPTION
Reverts terraform-ibm-modules/common-dev-assets#68

Looks like a regression so need to revert:
```
Terraform docs...........................................................Failed
- hook id: terraform_docs
- exit code: 1
```

This always fails, but no docs are updated by the hook

REGRESSION -> https://github.com/antonbabenko/pre-commit-terraform/issues/413