### PR TITLE
ci: workaround regression in antonbabenko/pre-commit-terraform

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,5 +11,12 @@
       ],
       "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
     }
+  ],
+  "packageRules": [
+    {
+      "description": "Disable updates antonbabenko/pre-commit-terraform until regression is fixed: https://github.com/antonbabenko/pre-commit-terraform/issues/413",
+      "matchPackageNames": ["antonbabenko/pre-commit-terraform"],
+      "enabled": false
+    }
   ]
 }


### PR DESCRIPTION
### Description

Creating rule that will not bump `antonbabenko/pre-commit-terraform` due to regression https://github.com/antonbabenko/pre-commit-terraform/issues/413

**Check the relevant boxes:**
- [ ] Bug fix (nonbreaking change that fixes an issue)
- [ ] New feature (nonbreaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [ ] CI related update (pipeline, etc.)

### Checklist

- [ ] If relevant, a test for the change has been added or updated as part of this PR.
- [ ] If relevant, documentation for the change has been added or updated as part of this PR.

### Merge

- Merge using "Squash and merge".
- Make sure to use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents. The commit message determines whether a new version of the modules needs to be released, and if so, which semver number to use).
