### PR TITLE
fix: Update Add examples pre commit hook

### DIFF
--- a/module-assets/.pre-commit-config.yaml
+++ b/module-assets/.pre-commit-config.yaml
@@ -101,7 +101,7 @@ repos:
       entry: python ci/terraformDocs.py
       language: python
       files: "README.md"
-      require_serial: true
+      pass_filenames: false
 # helm lint
 - repo: https://github.com/gruntwork-io/pre-commit
   rev: v0.1.17

--- a/module-assets/.pre-commit-config.yaml
+++ b/module-assets/.pre-commit-config.yaml
@@ -101,6 +101,7 @@ repos:
       entry: python ci/terraformDocs.py
       language: python
       files: "README.md"
+      require_serial: true
 # helm lint
 - repo: https://github.com/gruntwork-io/pre-commit
   rev: v0.1.17


### PR DESCRIPTION
### Description

at the end `terraformDocs` script deletes examples.md. It looks like hook touches README.md multiple times, and after first touch examples.md file is deleted. Therefore we get an error: 
```
Add examples section to README...........................................Failed

* hook id: add_examples

* files were modified by this hook

Error: template: content:3:3: executing "content" at <include "EXAMPLES.md">: error calling include: open EXAMPLES.md: no such file or directory

Error: template: content:3:3: executing "content" at <include "EXAMPLES.md">: error calling include: open EXAMPLES.md: no such file or directory

README.md updated successfully

helmlint.................................................................Passed

Makefile:85: recipe for target 'pre-commit' failed

make: *** [pre-commit] Error 1

The command "make pre-commit" failed and exited with 2 during .

```

**Check the relevant boxes:**
- [ ] Bug fix (nonbreaking change that fixes an issue)
- [ ] New feature (nonbreaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [x] CI related update (pipeline, etc.)

### Checklist

- [ ] If relevant, a test for the change has been added or updated as part of this PR.
- [ ] If relevant, documentation for the change has been added or updated as part of this PR.

### Merge

- Merge using "Squash and merge".
- Make sure to use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents. The commit message determines whether a new version of the modules needs to be released, and if so, which semver number to use).
