### PR TITLE
fix: Remove hashtag from Examples section (README)

### DIFF
--- a/module-assets/ci/terraformDocExamples.py
+++ b/module-assets/ci/terraformDocExamples.py
@@ -30,7 +30,11 @@ def prepare_example_lines(readme_titles, newlines):
         for readme_title in readme_titles:
             for key, value in readme_title.items():
                 prepare_line = (
-                    "- [" + value.strip() + "](" + key.replace("/README.md", "") + ")\n"
+                    "- ["
+                    + value.strip().replace("#", "")
+                    + "]("
+                    + key.replace("/README.md", "")
+                    + ")\n"
                 )
                 newlines.append(prepare_line)
     else:


### PR DESCRIPTION
### Description

Example name, which is added to Examples section, is generated from a title of an each Readme example file. If hashtag is included we need to remove it

**Check the relevant boxes:**
- [ ] Bug fix (nonbreaking change that fixes an issue)
- [ ] New feature (nonbreaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [x] CI related update (pipeline, etc.)

### Checklist

- [ ] If relevant, a test for the change has been added or updated as part of this PR.
- [ ] If relevant, documentation for the change has been added or updated as part of this PR.

### Merge

- Merge using "Squash and merge".
- Make sure to use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents. The commit message determines whether a new version of the modules needs to be released, and if so, which semver number to use).
