### PR TITLE
Revert "ci: workaround regression in antonbabenko/pre-commit-terraform"

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,12 +11,5 @@
       ],
       "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
     }
-  ],
-  "packageRules": [
-    {
-      "description": "Disable updates of antonbabenko/pre-commit-terraform until regression is fixed: https://github.com/antonbabenko/pre-commit-terraform/issues/413",
-      "matchPackageNames": ["antonbabenko/pre-commit-terraform"],
-      "enabled": false
-    }
   ]
 }


### PR DESCRIPTION
Reverts terraform-ibm-modules/common-dev-assets#71 as https://github.com/antonbabenko/pre-commit-terraform/issues/413 is now fixed.
By removing the rule renovate will bump to the latest version next times it runs.