### PR TITLE
fix: Do not run examples pre-commit hook if metadata does not exist

### DIFF
--- a/module-assets/ci/terraformDocExamples.py
+++ b/module-assets/ci/terraformDocExamples.py
@@ -59,8 +59,18 @@ def remove_examples_markdown():
         os.remove(examples_markdown)
 
 
+def is_examples_hook_exists():
+    exists = False
+    with open("README.md", "r") as reader:
+        lines = reader.readlines()
+        for line in lines:
+            if "BEGIN EXAMPLES HOOK" in line:
+                exists = True
+    return exists
+
+
 def main():
-    if os.path.isdir("examples"):
+    if os.path.isdir("examples") and is_examples_hook_exists():
         newlines = []
         readme_titles = get_readme_titles()
         prepare_example_lines(readme_titles, newlines)


### PR DESCRIPTION
### Description

If the metadata tags (BEGIN EXAMPLES HOOK) don’t exist, the hook does not add anything.

**Check the relevant boxes:**
- [x] Bug fix (nonbreaking change that fixes an issue)
- [ ] New feature (nonbreaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [ ] CI related update (pipeline, etc.)

### Checklist

- [ ] If relevant, a test for the change has been added or updated as part of this PR.
- [ ] If relevant, documentation for the change has been added or updated as part of this PR.

### Merge

- Merge using "Squash and merge".
- Make sure to use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents. The commit message determines whether a new version of the modules needs to be released, and if so, which semver number to use).
