### PR TITLE
Revert "ci: add mixed-line-ending hook"

### DIFF
--- a/module-assets/.pre-commit-config.yaml
+++ b/module-assets/.pre-commit-config.yaml
@@ -9,7 +9,6 @@ repos:
     - id: trailing-whitespace
     - id: check-merge-conflict
     - id: detect-private-key
-    - id: mixed-line-ending
 - repo: https://github.com/hadolint/hadolint
   rev: v2.10.0
   hooks:


### PR DESCRIPTION
Reverts terraform-ibm-modules/common-dev-assets#104

It seems to clash with the add_examples hook - need to debug and will add it back after