### PR TITLE
ci: configure checkov to ignore module-metadata.json

### DIFF
--- a/module-assets/.pre-commit-config.yaml
+++ b/module-assets/.pre-commit-config.yaml
@@ -48,6 +48,7 @@ repos:
       args:
         - --args=--skip-path=.scv
         - --args=--skip-path=Dockerfile
+        - --args=--skip-path=module-metadata.json
 - repo: https://github.com/syntaqx/git-hooks
   rev: v0.0.17
   hooks:


### PR DESCRIPTION
### Description

After adding the terraform-config-inspect hook, checkov is failing for some modules on the content of module-metadata.json
EG: `iam-account-settings-module`:

```
Passed checks: 0, Failed checks: 2, Skipped checks: 0
Check: CKV_SECRET_6: "Base64 High Entropy String"
	FAILED for resource: 50c5527d09191147222b2280e363ac8ef97bfa3a
	File: /module-metadata.json:324-325
		324 |         "restrict_create_platform_apikey": "api*********",
Check: CKV_SECRET_6: "Base64 High Entropy String"
	FAILED for resource: b939bb67ee5f5b13f7997dba58c31813ce8033f0
	File: /module-metadata.json:324-325
		324 |         "restric************************": "api_creation",
```

Since this file is auto generated, I think it is OK to add to ignore list

**Check the relevant boxes:**
- [ ] Bug fix (nonbreaking change that fixes an issue)
- [ ] New feature (nonbreaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [x] CI related update (pipeline, etc.)

### Checklist

- [ ] If relevant, a test for the change has been added or updated as part of this PR.
- [ ] If relevant, documentation for the change has been added or updated as part of this PR.

### Merge

- Merge using "Squash and merge".
- Make sure to use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents. The commit message determines whether a new version of the modules needs to be released, and if so, which semver number to use).
