### PR TITLE
ci: add mixed-line-ending pre-commit hook

### DIFF
--- a/module-assets/.pre-commit-config.yaml
+++ b/module-assets/.pre-commit-config.yaml
@@ -9,6 +9,9 @@ repos:
     - id: trailing-whitespace
     - id: check-merge-conflict
     - id: detect-private-key
+    - id: mixed-line-ending
+      args: ['--fix=lf']
+      description: Forces to replace line ending by the UNIX 'lf' character.
 - repo: https://github.com/hadolint/hadolint
   rev: v2.10.0
   hooks:


### PR DESCRIPTION
### Description

Add mixed-line-ending pre-commit hook

default settings of mixed_line_ending pre-commit hook have issues with terraform_docs hook. Therefore we need to force to use LF ending

>  Whereas Windows follows the original convention of a carriage return plus a line feed ( CRLF ) for line endings, operating systems like Linux and Mac use only the line feed ( LF ) character

example doc: https://gdevops.gitlab.io/tuto_git/tools/pre-commit/repos_hooks/repo_pre_commit_hooks/mixed-line-ending/mixed-line-ending.html

**Check the relevant boxes:**
- [ ] Bug fix (nonbreaking change that fixes an issue)
- [ ] New feature (nonbreaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [x] CI related update (pipeline, etc.)

### Checklist

- [ ] If relevant, a test for the change has been added or updated as part of this PR.
- [ ] If relevant, documentation for the change has been added or updated as part of this PR.

### Merge

- Merge using "Squash and merge".
- Make sure to use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents. The commit message determines whether a new version of the modules needs to be released, and if so, which semver number to use).
