### PR TITLE
ci: Don't run tests if only the module-metadata.json file is being updated in PR

### DIFF
--- a/module-assets/ci/run-tests.sh
+++ b/module-assets/ci/run-tests.sh
@@ -57,7 +57,8 @@ if [ ${IS_PR} == true ]; then
                          "Makefile"
                          "renovate.json"
                          "catalogValidationValues.json.template"
-                         ".one-pipeline.yaml")
+                         ".one-pipeline.yaml"
+                         "module-metadata.json")
 
   # Determine all files being changed in the PR, and add it to array
   changed_files="$(git diff --name-only "${TARGET_BRANCH}..HEAD" --)"


### PR DESCRIPTION
Don't run tests if only the module-metadata.json file is being updated in PR

**Check the relevant boxes:**
- [ ] Bug fix (nonbreaking change that fixes an issue)
- [ ] New feature (nonbreaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [ ] CI related update (pipeline, etc.)

### Checklist

- [ ] If relevant, a test for the change has been added or updated as part of this PR.
- [ ] If relevant, documentation for the change has been added or updated as part of this PR.

### Merge

- Merge using "Squash and merge".
- Make sure to use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents. The commit message determines whether a new version of the modules needs to be released, and if so, which semver number to use).
