### PR TITLE
fix: Run Generate terraform module metadata only for root tf files

### DIFF
--- a/module-assets/ci/terraform-config-inspect.sh
+++ b/module-assets/ci/terraform-config-inspect.sh
@@ -2,7 +2,7 @@
 set -e
 
 tf_files=()
-while IFS='' read -r line; do tf_files+=("$line"); done < <(find ./ -name "*.tf")
+while IFS='' read -r line; do tf_files+=("$line"); done < <(find ./ -name "*.tf" -maxdepth 1)
 
 if [ ${#tf_files[@]} -gt 0 ]; then
    terraform-config-inspect --json > module-metadata.json


### PR DESCRIPTION
### Description

We generate terraform metada only for terraform modules. To check if repo is terraform module we check for `.tf` files inside root only

**Check the relevant boxes:**
- [ ] Bug fix (nonbreaking change that fixes an issue)
- [ ] New feature (nonbreaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [x] CI related update (pipeline, etc.)

### Checklist

- [ ] If relevant, a test for the change has been added or updated as part of this PR.
- [ ] If relevant, documentation for the change has been added or updated as part of this PR.

### Merge

- Merge using "Squash and merge".
- Make sure to use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents. The commit message determines whether a new version of the modules needs to be released, and if so, which semver number to use).
