### PR TITLE
fix: update the command used to determine repo name in run-catalog-onboarding-pipeline.sh

### DIFF
--- a/module-assets/ci/run-catalog-onboarding-pipeline.sh
+++ b/module-assets/ci/run-catalog-onboarding-pipeline.sh
@@ -60,7 +60,7 @@ USE_DEFAULT_TARGZ=false
 DESTROY_ON_FAILURE=false
 PUBLISH_APIKEY_OVERRIDE="none"
 VALIDATION_APIKEY_OVERRIDE="none"
-REPO_NAME=$(basename "$(git rev-parse --show-toplevel)")
+REPO_NAME=$(basename "$(git config --get remote.origin.url)")
 
 # Loop through all args
 for arg in "$@"; do


### PR DESCRIPTION
### Description

`git rev-parse --show-toplevel` does not work in travis the way we mount repo code as a volume. So updating to use `git config --get remote.origin.url` which does work.

Testing:
Currently you get:
```
root@cb931b6b7032:/mnt# basename $(git rev-parse --show-toplevel)
mnt
```

With the fix you get:
```
root@cb931b6b7032:/mnt# basename "$(git config --get remote.origin.url)"
terraform-ibm-landing-zone
```

**Check the relevant boxes:**
- [x] Bug fix (nonbreaking change that fixes an issue)
- [ ] New feature (nonbreaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [x] CI related update (pipeline, etc.)

### Checklist

- [ ] If relevant, a test for the change has been added or updated as part of this PR.
- [ ] If relevant, documentation for the change has been added or updated as part of this PR.

### Merge

- Merge using "Squash and merge".
- Make sure to use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents. The commit message determines whether a new version of the modules needs to be released, and if so, which semver number to use).
