### PR TITLE
fix: makefile skip common dirs for go-module tests

### DIFF
--- a/module-assets/Makefile
+++ b/module-assets/Makefile
@@ -212,7 +212,7 @@ run-tests-local:
 
 # run unit tests for golang projects
 run-go-module-tests:
-	@run_cmd="go test ./... -count=1 -v -timeout 5m" && \
+	@run_cmd="go test $(go list ./... | grep -v /common-dev-assets/) -count=1 -v -timeout 5m" && \
 	if [ "$${NO_CONTAINER}" = "true" ]; \
 	then \
 		bash -c "$${run_cmd}"; \


### PR DESCRIPTION
### Description

Changed the Makefile task "run-go-module-tests" to exclude any test packages from the "common-dev-assets" directory, as those tests are not intended to be run during a Golang module project's unit tests.

**Check the relevant boxes:**
- [x] Bug fix (nonbreaking change that fixes an issue)
- [ ] New feature (nonbreaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [ ] CI related update (pipeline, etc.)

### Checklist

- [ ] If relevant, a test for the change has been added or updated as part of this PR.
- [ ] If relevant, documentation for the change has been added or updated as part of this PR.

### Merge

- Merge using "Squash and merge".
- Make sure to use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents. The commit message determines whether a new version of the modules needs to be released, and if so, which semver number to use).
