### PR TITLE
fix: makefile fix for go module test

### DIFF
--- a/module-assets/Makefile
+++ b/module-assets/Makefile
@@ -212,7 +212,7 @@ run-tests-local:
 
 # run unit tests for golang projects
 run-go-module-tests:
-	@run_cmd="go test $(go list ./... | grep -v /common-dev-assets/) -count=1 -v -timeout 5m" && \
+	@run_cmd="go test \$$(go list ./... | grep -v /common-dev-assets/) -count=1 -v -timeout 5m" && \
 	if [ "$${NO_CONTAINER}" = "true" ]; \
 	then \
 		bash -c "$${run_cmd}"; \


### PR DESCRIPTION
### Description

Needed more escape characters in the new command for run-go-module-tests action, which were needed for the "bash -c" to work correctly in GHA where no container is run

**Check the relevant boxes:**
- [x] Bug fix (nonbreaking change that fixes an issue)
- [ ] New feature (nonbreaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [ ] CI related update (pipeline, etc.)

### Checklist

- [ ] If relevant, a test for the change has been added or updated as part of this PR.
- [ ] If relevant, documentation for the change has been added or updated as part of this PR.

### Merge

- Merge using "Squash and merge".
- Make sure to use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents. The commit message determines whether a new version of the modules needs to be released, and if so, which semver number to use).
