### PR TITLE
fix: run examples hook only when tf files exist

### DIFF
--- a/module-assets/ci/terraformDocExamples.py
+++ b/module-assets/ci/terraformDocExamples.py
@@ -13,12 +13,21 @@ def get_readme_title(readme_file):
         return line
 
 
-# Return titles of all README files inside examples folder
+# check if folder contains any tf file
+def has_tf_files(path):
+    if any(File.endswith(".tf") for File in os.listdir(path)):
+        return True
+    else:
+        return False
+
+
+# Return titles of all README files inside examples folder.
 def get_readme_titles():
     readme_titles = []
     for readme_file in Path("examples").rglob("README.md"):
         path = str(readme_file)
-        if not ("/.") in path:
+        # ignore README file if it has dot(.) in a path or the parent path does not contain any tf file
+        if not ("/.") in path and has_tf_files(readme_file.parent):
             readme_title = get_readme_title(path)
             if readme_title:
                 data = {"path": path, "title": readme_title}


### PR DESCRIPTION
### Description

Run examples hook only inside folder which has README file and tf files

**Check the relevant boxes:**
- [x] Bug fix (nonbreaking change that fixes an issue)
- [ ] New feature (nonbreaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [ ] CI related update (pipeline, etc.)

### Checklist

- [ ] If relevant, a test for the change has been added or updated as part of this PR.
- [ ] If relevant, documentation for the change has been added or updated as part of this PR.

### Merge

- Merge using "Squash and merge".
- Make sure to use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents. The commit message determines whether a new version of the modules needs to be released, and if so, which semver number to use).
