### PR TITLE
add settings info to readme

### DIFF
--- a/module-assets/ci/module-template-automation/.terraform-docs-config-template-module.yaml
+++ b/module-assets/ci/module-template-automation/.terraform-docs-config-template-module.yaml
@@ -71,7 +71,7 @@ content: |-
     1.  Enter a name for the module in format {{ if $is_internal }}`<NAME>-module`{{- else if $is_external }}`terraform-ibm-<NAME>`{{ end }}, where `<NAME>` reflects the type of infrastructure that the module manages.
     &emsp;&emsp;&emsp;&emsp;<br>Use hyphens as delimiters for names with multiple words (for example, {{ if $is_internal }}`VPC`-module {{- else if $is_external }}terraform-ibm-`activity-tracker`{{ end }}).
     1.  Provide a short description of the module.
-    &emsp;&emsp;&emsp;&emsp;<br>The description is displayed under the repository title on the [organization page]({{ if $is_internal }}https://github.ibm.com/GoldenEye{{- else if $is_external }}https://github.com/terraform-ibm-modules{{ end }}) and in the **About** section of the repository. Use the description to help users understand what your repo does by looking at the description.
+    &emsp;&emsp;&emsp;&emsp;<br>The description is displayed under the repository name on the [organization page]({{ if $is_internal }}https://github.ibm.com/GoldenEye{{- else if $is_external }}https://github.com/terraform-ibm-modules{{ end }}) and in the **About** section of the repository. Use the description to help users understand the purpose of your module. For more information, see [module names and descriptions](implementation-guidelines.md#module-names-and-descriptions).
 
     ### Clone the repo and set up your development environment
 
@@ -82,6 +82,13 @@ content: |-
 
     Post a request in the [#project-goldeneye](https://ibm-cloudplatform.slack.com/archives/C02SDGCJAB1) Slack channel to have your repo added to Travis. For more information, see [Setting up Travis for a new repo](https://github.ibm.com/GoldenEye/documentation/blob/master/travis-setup.md) in the GoldenEye docs.
     {{- end }}
+
+    ### Update the repo name and description in source control
+
+    To help make sure that the repo name and description are not changed except through pull requests, add the repo name and description to the settings file.
+
+    1.  Open the [settings.yml](.github/settings.yml) file.
+    1.  Set the repo `name` and `description` fields with what you specified when you [created the repo](#create-a-repo-from-this-repo-template).
 
     ### Update the Terraform files
 


### PR DESCRIPTION
### Description

Adds info to the template readme file about setting the rep name and description in the settings.yml file

Related PRs:
- https://github.com/terraform-ibm-modules/documentation/pull/23
- https://github.com/terraform-ibm-modules/terraform-ibm-module-template/pull/142

**Check the relevant boxes:**
- [ ] Bug fix (nonbreaking change that fixes an issue)
- [ ] New feature (nonbreaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Examples or tests (addition or updates of examples or tests)
- [x] Documentation update
- [ ] CI related update (pipeline, etc.)

### Checklist

- [ ] If relevant, a test for the change has been added or updated as part of this PR.
- [ ] If relevant, documentation for the change has been added or updated as part of this PR.

### Merge

- Merge using "Squash and merge".
- Make sure to use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents. The commit message determines whether a new version of the modules needs to be released, and if so, which semver number to use).
