### PR TITLE
ci: update to terraform 1.3.3

### DIFF
--- a/module-assets/ci/install-deps.sh
+++ b/module-assets/ci/install-deps.sh
@@ -160,8 +160,8 @@ echo "COMPLETE"
 # terraform
 #######################################
 
- # Locking into v1.2.9 until https://github.ibm.com/GoldenEye/issues/issues/2858 is complete
-TERRAFORM_VERSION=v1.2.9
+ # renovate: datasource=github-releases depName=hashicorp/terraform
+TERRAFORM_VERSION=v1.3.3
 # 'v' prefix required for renovate to query github.com for new release, but needs to be removed to pull from hashicorp.com
 TERRAFORM_VERSION="${TERRAFORM_VERSION:1}"
 BINARY=terraform


### PR DESCRIPTION
### Description

We need to go to >=1.3.0 in order to migrate some modules away from the Experiment "module_variable_optional_attrs"
See https://developer.hashicorp.com/terraform/language/upgrade-guides

**Check the relevant boxes:**
- [ ] Bug fix (nonbreaking change that fixes an issue)
- [x] New feature (nonbreaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [ ] CI related update (pipeline, etc.)

### Checklist

- [ ] If relevant, a test for the change has been added or updated as part of this PR.
- [ ] If relevant, documentation for the change has been added or updated as part of this PR.

### Merge

- Merge using "Squash and merge".
- Make sure to use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents. The commit message determines whether a new version of the modules needs to be released, and if so, which semver number to use).
