### PR TITLE
Replace checkov pre-commit hook with official one

### DIFF
--- a/module-assets/.pre-commit-config.yaml
+++ b/module-assets/.pre-commit-config.yaml
@@ -57,11 +57,17 @@ repos:
     - id: terragrunt_validate
     - id: terraform_tfsec
       files: '\.tf'
-    - id: terraform_checkov
+# checkov (does not require checkov to be installed locally to run)
+- repo: https://github.com/bridgecrewio/checkov.git
+  rev: 2.2.63
+  hooks:
+    - id: checkov
       args:
-        - --args=--skip-path=.scv
-        - --args=--skip-path=Dockerfile
-        - --args=--skip-path=module-metadata.json
+        - --skip-path=.scv
+        - --skip-path=Dockerfile
+        - --skip-path=module-metadata.json
+        - --skip-check=CKV_GHA*
+        - --skip-check=CKV2_GHA*
 - repo: https://github.com/syntaqx/git-hooks
   rev: v0.0.17
   hooks:

--- a/module-assets/.pre-commit-config.yaml
+++ b/module-assets/.pre-commit-config.yaml
@@ -66,8 +66,7 @@ repos:
         - --skip-path=.scv
         - --skip-path=Dockerfile
         - --skip-path=module-metadata.json
-        - --skip-check=CKV_GHA*
-        - --skip-check=CKV2_GHA*
+        - --skip-framework=github_actions
 - repo: https://github.com/syntaqx/git-hooks
   rev: v0.0.17
   hooks:


### PR DESCRIPTION
### Description

Replace checkov pre-commit hook with official one so checkov no longer needs to be installed locally (this hook install it as part of a virtual env)

**Check the relevant boxes:**
- [ ] Bug fix (nonbreaking change that fixes an issue)
- [ ] New feature (nonbreaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [ ] CI related update (pipeline, etc.)

### Checklist

- [ ] If relevant, a test for the change has been added or updated as part of this PR.
- [ ] If relevant, documentation for the change has been added or updated as part of this PR.

### Merge

- Merge using "Squash and merge".
- Make sure to use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents. The commit message determines whether a new version of the modules needs to be released, and if so, which semver number to use).
