### PR TITLE
ci: remove brew dependency

### DIFF
--- a/module-assets/Brewfile
+++ b/module-assets/Brewfile
@@ -1,4 +1,1 @@
-tap "homebrew/bundle"
-tap "homebrew/cask"
-tap "homebrew/core"
-brew "checkov"
+# Delete this file once https://github.ibm.com/GoldenEye/issues/issues/3271 is complete

--- a/module-assets/Brewfile
+++ b/module-assets/Brewfile
@@ -1,1 +1,1 @@
-# Delete this file once https://github.ibm.com/GoldenEye/issues/issues/3271 is complete
+# Delete this file once the Brewfile symlink is remove from all repos

--- a/module-assets/Makefile
+++ b/module-assets/Makefile
@@ -63,7 +63,6 @@ all: dependency-install-darwin-linux dependency-pre-commit
 
 dependency-install-darwin-linux:
 	./ci/install-deps.sh
-	brew bundle install
 
 dependency-pre-commit:
 	pre-commit install

--- a/repo_migration.sh
+++ b/repo_migration.sh
@@ -23,7 +23,7 @@ function confirm() {
 
 function validate_prereqs(){
   echo "Validating pre reqs..."
-  REQS=("git" "brew" "python3" "go" "curl" "unzip" )
+  REQS=("git" "python3" "go" "curl" "unzip" )
 
   # Iterate the string array using for loop
   for val in "${REQS[@]}"; do


### PR DESCRIPTION
### Description

We no longer require Brew since checkov does not need to be installed anymore after merging https://github.com/terraform-ibm-modules/common-dev-assets/pull/222

**Check the relevant boxes:**
- [ ] Bug fix (nonbreaking change that fixes an issue)
- [ ] New feature (nonbreaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [ ] CI related update (pipeline, etc.)

### Checklist

- [ ] If relevant, a test for the change has been added or updated as part of this PR.
- [ ] If relevant, documentation for the change has been added or updated as part of this PR.

### Merge

- Merge using "Squash and merge".
- Make sure to use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents. The commit message determines whether a new version of the modules needs to be released, and if so, which semver number to use).
