### PR TITLE
ci: remove source of .bashrc and .profile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,15 +37,9 @@ jobs:
       # Check for pre-commit updates if it is a renovate PR
       - name: Renovate sweeper
         run: |
-          # Setup environment since GHA does not run the containers entrypoint
-          . /root/.bashrc
-          . /root/.profile
           make renovate-sweeper
 
       # run pre-commit against all files
       - name: Pre-commit
         run: |
-          # Setup environment since GHA does not run the containers entrypoint
-          . /root/.bashrc
-          . /root/.profile
           make pre-commit

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2022-10-25T17:03:26Z",
+  "generated_at": "2022-11-17T12:27:20Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -70,7 +70,7 @@
         "hashed_secret": "3a272afad27cd2a102600d836c3684fb32a4303b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 19,
+        "line_number": 15,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/pipeline-assets/contanerize.sh
+++ b/pipeline-assets/contanerize.sh
@@ -1,8 +1,4 @@
 #!/usr/bin/env bash
-# For use within Tekton pipeline
-# shellcheck disable=SC1090
-source ~/.bashrc
-source ~/.profile
 
 if [[ "$PIPELINE_DEBUG" == 1 ]]; then
   trap env EXIT


### PR DESCRIPTION
### Description

With Brew gone, we no longer need to source the .bashrc or .profile

**Check the relevant boxes:**
- [ ] Bug fix (nonbreaking change that fixes an issue)
- [ ] New feature (nonbreaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [x] CI related update (pipeline, etc.)

### Checklist

- [ ] If relevant, a test for the change has been added or updated as part of this PR.
- [ ] If relevant, documentation for the change has been added or updated as part of this PR.

### Merge

- Merge using "Squash and merge".
- Make sure to use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents. The commit message determines whether a new version of the modules needs to be released, and if so, which semver number to use).
