### PR TITLE
ci: add support to install-deps.sh to place binaries into custom location

### DIFF
--- a/module-assets/ci/install-deps.sh
+++ b/module-assets/ci/install-deps.sh
@@ -1,9 +1,14 @@
 #!/bin/bash
 
-set -o errexit
-set -o pipefail
-set -o nounset
-#set -o xtrace
+set -e
+
+# Place binaries in /usr/local/bin unless $CUSTOM_DIRECTORY defined
+if [[ -z "${CUSTOM_DIRECTORY}" ]]; then
+  DIRECTORY="/usr/local/bin"
+else
+  DIRECTORY="${CUSTOM_DIRECTORY}"
+  mkdir -p "${DIRECTORY}"
+fi
 
 # Determine OS type
 if [[ $OSTYPE == 'darwin'* ]]; then
@@ -60,23 +65,22 @@ function verify_alternative {
 
 }
 
-# Function to copy and replace binary in /usr/local/bin
+# Function to copy and replace binary in $DIRECTORY
 function copy_replace_binary {
 
   binary=$1
   tmp_dir=$2
-  dir=/usr/local/bin
 
-  echo "Placing ${binary} binary in ${dir} and making executable.."
+  echo "Placing ${binary} binary in ${DIRECTORY} and making executable.."
   arg=""
-  if ! [ -w "${dir}" ]; then
-    echo "No write permission to $dir. Attempting to run with sudo..."
+  if ! [ -w "${DIRECTORY}" ]; then
+    echo "No write permission to ${DIRECTORY}. Attempting to run with sudo..."
     arg=sudo
   fi
   # Need to delete if exists already in case it is a symlink which cannot be overwritten using cp -r
-  ${arg} rm -f "${dir}/${binary}"
-  ${arg} cp -r "${tmp_dir}/${binary}" "${dir}"
-  ${arg} chmod +x "${dir}/${binary}"
+  ${arg} rm -f "${DIRECTORY}/${binary}"
+  ${arg} cp -r "${tmp_dir}/${binary}" "${DIRECTORY}"
+  ${arg} chmod +x "${DIRECTORY}/${binary}"
 
 }
 


### PR DESCRIPTION
### Description

ci: add support to install-deps.sh to place binaries into custom location. 
It will be used by the new IaC Tekton pipeline to ensure we lock into exact dependency versions across all pipeline stages.

**Check the relevant boxes:**
- [ ] Bug fix (nonbreaking change that fixes an issue)
- [x] New feature (nonbreaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [x] CI related update (pipeline, etc.)

### Checklist

- [ ] If relevant, a test for the change has been added or updated as part of this PR.
- [ ] If relevant, documentation for the change has been added or updated as part of this PR.

### Merge

- Merge using "Squash and merge".
- Make sure to use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents. The commit message determines whether a new version of the modules needs to be released, and if so, which semver number to use).
