### PR TITLE
ci: update isort pre-commit hook

### DIFF
--- a/module-assets/.pre-commit-config.yaml
+++ b/module-assets/.pre-commit-config.yaml
@@ -93,8 +93,8 @@ repos:
         # https://flake8.pycqa.org/en/latest/user/error-codes.html
         - "--ignore=E203,E501,W503"
 # isort
-- repo: https://github.com/pre-commit/mirrors-isort
-  rev: v5.10.1
+- repo: https://github.com/pycqa/isort
+  rev: 5.10.1
   hooks:
   - id: isort
     args: ["--profile", "black", "--filter-files"]


### PR DESCRIPTION
### Description

https://github.com/pre-commit/mirrors-isort is now deprecated and we should be using https://github.com/PyCQA/isort instead

**Check the relevant boxes:**
- [ ] Bug fix (nonbreaking change that fixes an issue)
- [ ] New feature (nonbreaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [ ] CI related update (pipeline, etc.)

### Checklist

- [ ] If relevant, a test for the change has been added or updated as part of this PR.
- [ ] If relevant, documentation for the change has been added or updated as part of this PR.

### Merge

- Merge using "Squash and merge".
- Make sure to use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents. The commit message determines whether a new version of the modules needs to be released, and if so, which semver number to use).
