### PR TITLE
fix: remove IBM provider from terraform cache

### DIFF
--- a/module-assets/ci/terraformConfigInspect.py
+++ b/module-assets/ci/terraformConfigInspect.py
@@ -2,6 +2,7 @@
 
 import glob
 import os
+import shutil
 import sys
 from pathlib import Path
 from subprocess import PIPE, Popen
@@ -38,8 +39,18 @@ def run_metadata_generator(file_path, terraform_provider):
         os.system("terraform-config-inspect --json > %s" % (file_path))
 
 
+def remove_tf_IBM_provider():
+    dirpath = Path(".terraform/providers/registry.terraform.io/ibm-cloud")
+    if dirpath.exists() and dirpath.is_dir():
+        shutil.rmtree(dirpath)
+
+
 def main():
     if glob.glob("*.tf"):
+
+        # remove IBM provider. Must be removed so we make sure that local terraform cache has the latest version only
+        remove_tf_IBM_provider()
+
         # always run terraform init
         error_code = terraform_init()
 


### PR DESCRIPTION
### Description

terraform-config-inspect hook uses IBM provider from terraform cache (.terraform folder). It can happens that cache contains older versions. To make sure we always use the latest version of provider only, we need to delete old versions before we run `terraform init`.

**Check the relevant boxes:**
- [x] Bug fix (nonbreaking change that fixes an issue)
- [ ] New feature (nonbreaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [ ] CI related update (pipeline, etc.)

### Checklist

- [ ] If relevant, a test for the change has been added or updated as part of this PR.
- [ ] If relevant, documentation for the change has been added or updated as part of this PR.

### Merge

- Merge using "Squash and merge".
- Make sure to use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents. The commit message determines whether a new version of the modules needs to be released, and if so, which semver number to use).
