### PR TITLE
fix: lock into checkov version and disable with renovate

### DIFF
--- a/module-assets/.pre-commit-config.yaml
+++ b/module-assets/.pre-commit-config.yaml
@@ -59,7 +59,7 @@ repos:
       files: '\.tf'
 # checkov (does not require checkov to be installed locally to run)
 - repo: https://github.com/bridgecrewio/checkov.git
-  rev: 2.2.100
+  rev: 2.2.99
   hooks:
     - id: checkov
       args:

--- a/renovate.json
+++ b/renovate.json
@@ -16,5 +16,12 @@
       "matchStrings": ["\\s+image: (?<depName>.*?)(?::(?<currentValue>.*?))?@(?<currentDigest>sha256:[a-f0-9]+)\\s"],
       "datasourceTemplate": "docker"
     }
+  ],
+  "packageRules": [
+    {
+      "description": "Ignore updates to checkov until https://github.ibm.com/GoldenEye/issues/issues/3348 is fixed",
+      "matchPackageNames": ["bridgecrewio/checkov"],
+      "enabled": false
+    }
   ]
 }


### PR DESCRIPTION
### Description

lock into checkov version and disable with renovate until custom rule is added

**Check the relevant boxes:**
- [x] Bug fix (nonbreaking change that fixes an issue)
- [ ] New feature (nonbreaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [ ] CI related update (pipeline, etc.)

### Checklist

- [ ] If relevant, a test for the change has been added or updated as part of this PR.
- [ ] If relevant, documentation for the change has been added or updated as part of this PR.

### Merge

- Merge using "Squash and merge".
- Make sure to use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents. The commit message determines whether a new version of the modules needs to be released, and if so, which semver number to use).
