### PR TITLE
ci: temporarily enable and priortise bump of ibm provider

### DIFF
--- a/commonRenovateConfig.json
+++ b/commonRenovateConfig.json
@@ -58,8 +58,7 @@
       "rangeStrategy": "bump",
       "group": true,
       "groupName": "required_provider",
-      "schedule": ["every 4 months on the 1st through 5th day of the month"],
-      "prPriority": 9
+      "prPriority": 11
     },
     {
       "description": "Prioritise terraform module updates",


### PR DESCRIPTION
### Description

We need to bump to minimum required version for all modules to 1.48.0 to pickup the fix / workaround for https://github.ibm.com/GoldenEye/issues/issues/3072
Once done, we will revert back

**Check the relevant boxes:**
- [x] Bug fix (nonbreaking change that fixes an issue)
- [ ] New feature (nonbreaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [x] CI related update (pipeline, etc.)

### Checklist

- [ ] If relevant, a test for the change has been added or updated as part of this PR.
- [ ] If relevant, documentation for the change has been added or updated as part of this PR.

### Merge

- Merge using "Squash and merge".
- Make sure to use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents. The commit message determines whether a new version of the modules needs to be released, and if so, which semver number to use).
