### PR TITLE
ci: rename git submodule hook to human friendly name

### DIFF
--- a/module-assets/.pre-commit-config.yaml
+++ b/module-assets/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
 - repo: local
   hooks:
     - id: git-submodule-version-check
-      name: git-submodule-version-check
+      name: Check git submodule up to date
       description: Hook that will fail if local common-dev-assets git submodule is older than the one currently on primary branch
       entry: ci/submoduleVersionCheck.sh
       language: script


### PR DESCRIPTION
### Description

ci: rename git submodule hook to human friendly name

**Check the relevant boxes:**
- [ ] Bug fix (nonbreaking change that fixes an issue)
- [ ] New feature (nonbreaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [ ] CI related update (pipeline, etc.)

### Checklist

- [ ] If relevant, a test for the change has been added or updated as part of this PR.
- [ ] If relevant, documentation for the change has been added or updated as part of this PR.

### Merge

- Merge using "Squash and merge".
- Make sure to use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents. The commit message determines whether a new version of the modules needs to be released, and if so, which semver number to use).
