### PR TITLE
fix: remove Brewfile refs from migration script

### DIFF
--- a/repo_migration.sh
+++ b/repo_migration.sh
@@ -79,7 +79,7 @@ function add_git_submodule() {
 # Create Symbolic links
 function create_symbolic_links() {
     echo "Creating symbolic links"
-    for file in ".pre-commit-config.yaml" "Makefile" "ci" "Brewfile"; do
+    for file in ".pre-commit-config.yaml" "Makefile" "ci"; do
       if [ -f "${file}" ]
       then
         if [[ "yes" == $(confirm "Replace ${file} [y/N]? (Required for migration)") ]]
@@ -95,8 +95,6 @@ function create_symbolic_links() {
     git add ci
     ln -s common-dev-assets/module-assets/Makefile Makefile
     git add Makefile
-    ln -s common-dev-assets/module-assets/Brewfile Brewfile
-    git add Brewfile
 
 }
 
@@ -151,7 +149,6 @@ then
     rm .github/workflows/release.yml
     rmdir .github/workflows > /dev/null 2>&1
     rm .github/settings.yml
-    rm Brewfile.lock.json
     rmdir .github > /dev/null 2>&1
     git rm -f  common-dev-assets
     find . -name .gitmodules -maxdepth 1 -type f -empty -print -delete


### PR DESCRIPTION
### Description

remove Brewfile refs from migration script - we don't use brew anymore

**Check the relevant boxes:**
- [x] Bug fix (nonbreaking change that fixes an issue)
- [ ] New feature (nonbreaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [ ] CI related update (pipeline, etc.)

### Checklist

- [ ] If relevant, a test for the change has been added or updated as part of this PR.
- [ ] If relevant, documentation for the change has been added or updated as part of this PR.

### Merge

- Merge using "Squash and merge".
- Make sure to use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents. The commit message determines whether a new version of the modules needs to be released, and if so, which semver number to use).
