### PR TITLE
re-enable bumping checkov with renovate 

### DIFF
--- a/module-assets/.pre-commit-config.yaml
+++ b/module-assets/.pre-commit-config.yaml
@@ -59,8 +59,6 @@ repos:
       files: '\.tf'
 # checkov (does not require checkov to be installed locally to run)
 - repo: https://github.com/bridgecrewio/checkov.git
-  # Need to use custom renovate rule in renovate.json so renovate only bumps the checkov version based on GIT releases (See https://github.ibm.com/GoldenEye/issues/issues/3348)
-  # renovate: datasource=github-releases depName=bridgecrewio/checkov
   rev: 2.2.127
   hooks:
     - id: checkov

--- a/renovate.json
+++ b/renovate.json
@@ -15,20 +15,6 @@
       "fileMatch": ["^.github/workflows/.*.yml$"],
       "matchStrings": ["\\s+image: (?<depName>.*?)(?::(?<currentValue>.*?))?@(?<currentDigest>sha256:[a-f0-9]+)\\s"],
       "datasourceTemplate": "docker"
-    },
-    {
-      "fileMatch": ["^module-assets/.pre-commit-config.yaml$"],
-      "matchStrings": [
-        "datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s.*?rev: (?<currentValue>.*)\\s"
-      ],
-      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
-    }
-  ],
-  "packageRules": [
-    {
-      "description": "Ignore updates to checkov pre-commit and use above custom rule (workaround for https://github.ibm.com/GoldenEye/issues/issues/3348)",
-      "matchPackageNames": ["bridgecrewio/checkov"],
-      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
### Description

After some testing it seems all git tags do work with the pre-commit hook, so re-enabling the renovate rule

**Check the relevant boxes:**
- [ ] Bug fix (nonbreaking change that fixes an issue)
- [ ] New feature (nonbreaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [x] CI related update (pipeline, etc.)

### Checklist

- [ ] If relevant, a test for the change has been added or updated as part of this PR.
- [ ] If relevant, documentation for the change has been added or updated as part of this PR.

### Merge

- Merge using "Squash and merge".
- Make sure to use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents. The commit message determines whether a new version of the modules needs to be released, and if so, which semver number to use).
