### PR TITLE
Revert "Update icd-region-prefs.yaml"

### DIFF
--- a/common-go-assets/icd-region-prefs.yaml
+++ b/common-go-assets/icd-region-prefs.yaml
@@ -1,8 +1,11 @@
-# BYOK for backups is available only in us-south and eu-de.
+# BYOK for backups is available only in US regions us-south and us-east, and eu-de.
 ---
 - name: eu-de
   useForTest: true
   testPriority: 1
+- name: us-east
+  useForTest: true
+  testPriority: 2
 - name: us-south
   useForTest: true
   testPriority: 3


### PR DESCRIPTION
Reverts terraform-ibm-modules/common-dev-assets#275

us-east is a valid region for instance deployment. The confusion is that the doc says:

> Only keys in the `us-south` and `eu-de` are durable to region failures. To ensure that your backups are available even if a region failure occurs, you must use a key from `us-south` or `eu-de`, regardless of your deployment’s location

They key here being "regardless of your deployment’s location"