### PR TITLE
Update icd-region-prefs.yaml

### DIFF
--- a/common-go-assets/icd-region-prefs.yaml
+++ b/common-go-assets/icd-region-prefs.yaml
@@ -1,11 +1,10 @@
 # BYOK for backups is available only in US regions us-south and us-east, and eu-de.
+# However, to ensure that backups are available if a region failure occurs, you must use a key from us-south or eu-de.
+# Doc: https://cloud.ibm.com/docs/cloud-databases?topic=cloud-databases-key-protect&interface=ui#key-byok
 ---
 - name: eu-de
   useForTest: true
   testPriority: 1
-- name: us-east
-  useForTest: true
-  testPriority: 2
 - name: us-south
   useForTest: true
-  testPriority: 3
+  testPriority: 2


### PR DESCRIPTION
### Description

When testing we found that if selecting `us-east` the following error occurs:
```
Only us-south backup encryption keys are supported
```
When testing with `us-south` or `eu-de` we did not face this issue, so updating the yaml prefs

**Check the relevant boxes:**
- [ ] Bug fix (nonbreaking change that fixes an issue)
- [ ] New feature (nonbreaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [x] CI related update (pipeline, etc.)

### Checklist

- [ ] If relevant, a test for the change has been added or updated as part of this PR.
- [ ] If relevant, documentation for the change has been added or updated as part of this PR.

### Merge

- Merge using "Squash and merge".
- Make sure to use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents. The commit message determines whether a new version of the modules needs to be released, and if so, which semver number to use).
