### PR TITLE
set set -o pipefail in run-tests.sh

### DIFF
--- a/module-assets/ci/run-tests.sh
+++ b/module-assets/ci/run-tests.sh
@@ -8,6 +8,7 @@
 #
 
 set -e
+set -o pipefail
 
 # Determine if PR
 IS_PR=false


### PR DESCRIPTION
### Description

We need to now use `set -o pipefail` to ensure we correctly capture the exit code of the tests, otherwise due to the fact we use `tee`, the tests will always exit with a 0 result, which is not correct

**Check the relevant boxes:**
- [x] Bug fix (nonbreaking change that fixes an issue)
- [ ] New feature (nonbreaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [ ] CI related update (pipeline, etc.)

### Checklist

- [ ] If relevant, a test for the change has been added or updated as part of this PR.
- [ ] If relevant, documentation for the change has been added or updated as part of this PR.

### Merge

- Merge using "Squash and merge".
- Make sure to use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents. The commit message determines whether a new version of the modules needs to be released, and if so, which semver number to use).
