### PR TITLE
fix: git-submodule-version-check hook check version with local primary branch

### DIFF
--- a/module-assets/ci/submoduleVersionCheck.sh
+++ b/module-assets/ci/submoduleVersionCheck.sh
@@ -72,7 +72,7 @@ function main() {
             submodule_version_remote=$(get_submodule_version ${git_submodule_name})
 
             if [ "${submodule_version_current}" != "${submodule_version_remote}" ]; then
-                printf "\nDetected common-dev-assets git submodule commit ID is older than the one in primary branch. Make sure your branch is rebased with remote primary branch and run the following command to sync with primary branch: git submodule update --rebase."
+                printf "\nDetected common-dev-assets git submodule commit ID is older than the one in primary branch. Make sure your branch is rebased with remote primary branch and run the following command to sync with primary branch: git submodule update --rebase"
                 rm -fr "${temp_dir}"
                 exit 1
             fi

--- a/module-assets/ci/submoduleVersionCheck.sh
+++ b/module-assets/ci/submoduleVersionCheck.sh
@@ -72,7 +72,7 @@ function main() {
             submodule_version_remote=$(get_submodule_version ${git_submodule_name})
 
             if [ "${submodule_version_current}" != "${submodule_version_remote}" ]; then
-                printf "\nDetected common-dev-assets git submodule commit ID is older than the one in primary branch. Make sure your branch is rebased with remote primary branch and run the following command to sync with primary branch: git submodule update --rebase"
+                printf "\nDetected common-dev-assets git submodule commit ID is either older than the one in primary branch, or not at the latest. To fix, make sure your branch is rebased with remote primary branch, and then run the following command to sync the git submodule with primary branch: 'git submodule update --rebase'.\nAlternatively you can run 'git submodule update --remote --merge' to update your branch to the latest available git submodule, however this is not recommended, as you will likely soon end up with conflicts to resolve due to the renovate automation that is updating the git submodule version in primary branch very frequently."
                 rm -fr "${temp_dir}"
                 exit 1
             fi


### PR DESCRIPTION


### Description
Before we check submodule version with primary branch we need to have the latest version of primary branch first. Therefore we clone a new copy of it before we do comparison. 


**Check the relevant boxes:**
- [ ] Bug fix (nonbreaking change that fixes an issue)
- [ ] New feature (nonbreaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [ ] CI related update (pipeline, etc.)

### Checklist

- [ ] If relevant, a test for the change has been added or updated as part of this PR.
- [ ] If relevant, documentation for the change has been added or updated as part of this PR.

### Merge

- Merge using "Squash and merge".
- Make sure to use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents. The commit message determines whether a new version of the modules needs to be released, and if so, which semver number to use).
