### PR TITLE
ci: enable provider bumping in order to consume latest ibm provider

### DIFF
--- a/commonRenovateConfig.json
+++ b/commonRenovateConfig.json
@@ -53,7 +53,7 @@
     },
     {
       "description": "Disable terraform provider updates by default. To enable, set enable to true below and renovate will priortise bumping this. We only need to bump this version to consume required bug fixes and/or new provider features.",
-      "enabled": false,
+      "enabled": true,
       "matchManagers": ["terraform"],
       "matchDepTypes": ["required_provider"],
       "rangeStrategy": "bump",


### PR DESCRIPTION
### Description

The latest ibm provider contains a couple of fixes we want to consume across the board. The main one being https://github.com/IBM-Cloud/terraform-provider-ibm/pull/4209 which was causing rate limiting issues

**Check the relevant boxes:**
- [ ] Bug fix (nonbreaking change that fixes an issue)
- [ ] New feature (nonbreaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [x] CI related update (pipeline, etc.)

### Checklist

- [ ] If relevant, a test for the change has been added or updated as part of this PR.
- [ ] If relevant, documentation for the change has been added or updated as part of this PR.

### Merge

- Merge using "Squash and merge".
- Make sure to use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents. The commit message determines whether a new version of the modules needs to be released, and if so, which semver number to use).
