### PR TITLE
fix: check all commit ids of a submodule

### DIFF
--- a/module-assets/ci/submoduleVersionCheck.sh
+++ b/module-assets/ci/submoduleVersionCheck.sh
@@ -73,13 +73,13 @@ function main() {
 
             # get all git submodule commit ids. The list is sorted in descending order (the latest commit id is the first element)
             cd "${git_submodule_name}"
-            git_submodule_commit_ids=$(git rev-list main)
+            git_submodule_commit_ids=$(git rev-list origin)
 
             while IFS= read -r git_submodule_commit_id
             do
                 # if submodule_version_main_branch is found before submodule_version_current then the current submodule version is older than the primary branch version and script must fail
                 if [ "${submodule_version_main_branch}" = "${git_submodule_commit_id}" ]; then
-                    printf "\nDetected common-dev-assets git submodule commit ID is either older than the one in primary branch, or not at the latest. To fix, make sure your branch is rebased with remote primary branch, and then run the following command to sync the git submodule with primary branch: 'git submodule update --rebase'.\nAlternatively you can run 'git submodule update --remote --merge' to update your branch to the latest available git submodule, however this is not recommended, as you will likely soon end up with conflicts to resolve due to the renovate automation that is updating the git submodule version in primary branch very frequently."
+                    printf "\nDetected common-dev-assets git submodule commit ID is older than the one in primary branch. To fix, make sure your branch is rebased with remote primary branch, and then run the following command to sync the git submodule with primary branch: 'git submodule update --rebase'.\nAlternatively you can run 'git submodule update --remote --merge' to update your branch to the latest available git submodule, however this is not recommended, as you will likely soon end up with conflicts to resolve due to the renovate automation that is updating the git submodule version in primary branch very frequently."
                     rm -fr "${temp_dir}"
                     exit 1
                 fi

--- a/module-assets/ci/submoduleVersionCheck.sh
+++ b/module-assets/ci/submoduleVersionCheck.sh
@@ -4,12 +4,13 @@ set -e
 # Script checks if commit id of the git submodule in a PR branch is older than the one in a main branch or remote.
 # If commit id is older then error is thrown.
 # pseudocode:
-#   if local_commit_id == main_branch_commit_id
-#   then OK
-#   else check remote submodule id
-#       if local_commit_id == remote_commit_id
-#       then OK
-#       else throw Error
+#   if local_commit_id != main_branch_commit_id
+#   then
+#       get all submodule commit ids
+#       iterate through commit ids
+#           if local_commit_id is found before main_branch_commit_id then OK
+#           else throw Error
+#   else OK
 
 
 function get_submodule_version() {
@@ -69,17 +70,26 @@ function main() {
         echo "Primary branch submodule version: ${submodule_version_main_branch}"
 
         if [ "${submodule_version_current}" != "${submodule_version_main_branch}" ]; then
-            # update submodule version with remote
-            git submodule update --remote --merge
-            submodule_version_remote=$(get_submodule_version ${git_submodule_name})
-            echo "Remote submodule version: ${submodule_version_remote}"
 
-            if [ "${submodule_version_current}" != "${submodule_version_remote}" ]; then
-                printf "\nDetected common-dev-assets git submodule commit ID is either older than the one in primary branch, or not at the latest. To fix, make sure your branch is rebased with remote primary branch, and then run the following command to sync the git submodule with primary branch: 'git submodule update --rebase'.\nAlternatively you can run 'git submodule update --remote --merge' to update your branch to the latest available git submodule, however this is not recommended, as you will likely soon end up with conflicts to resolve due to the renovate automation that is updating the git submodule version in primary branch very frequently."
-                rm -fr "${temp_dir}"
-                exit 1
-            fi
+            # get all git submodule commit ids. The list is sorted in descending order (the latest commit id is the first element)
+            cd "${git_submodule_name}"
+            git_submodule_commit_ids=$(git rev-list main)
+
+            while IFS= read -r git_submodule_commit_id
+            do
+                # if submodule_version_main_branch is found before submodule_version_current then the current submodule version is older than the primary branch version and script must fail
+                if [ "${submodule_version_main_branch}" = "${git_submodule_commit_id}" ]; then
+                    printf "\nDetected common-dev-assets git submodule commit ID is either older than the one in primary branch, or not at the latest. To fix, make sure your branch is rebased with remote primary branch, and then run the following command to sync the git submodule with primary branch: 'git submodule update --rebase'.\nAlternatively you can run 'git submodule update --remote --merge' to update your branch to the latest available git submodule, however this is not recommended, as you will likely soon end up with conflicts to resolve due to the renovate automation that is updating the git submodule version in primary branch very frequently."
+                    rm -fr "${temp_dir}"
+                    exit 1
+                fi
+
+                if [ "${submodule_version_current}" = "${git_submodule_commit_id}" ]; then
+                    break
+                fi
+            done <<< "${git_submodule_commit_ids}"
         fi
+
         rm -fr "${temp_dir}"
     fi
 }


### PR DESCRIPTION
### Description

We need to make sure that the PR submodule commit id is the same or older than primary branch  submodule commit id.

**Check the relevant boxes:**
- [X] Bug fix (nonbreaking change that fixes an issue)
- [ ] New feature (nonbreaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [ ] CI related update (pipeline, etc.)

### Checklist

- [ ] If relevant, a test for the change has been added or updated as part of this PR.
- [ ] If relevant, documentation for the change has been added or updated as part of this PR.

### Merge

- Merge using "Squash and merge".
- Make sure to use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents. The commit message determines whether a new version of the modules needs to be released, and if so, which semver number to use).
