### PR TITLE
ci: mount netrc in pre-commit make commands

### DIFF
--- a/module-assets/Makefile
+++ b/module-assets/Makefile
@@ -88,7 +88,7 @@ docker-run:
 #
 
 # pre-commit for repos with terraform code
-# (in container approach, not directly mounting ~/.ssh because we will be changing the permissions, so creating backup and mounting that instead)
+# (in container approach, not directly mounting ~/.ssh or ~/.netrc because we will be changing the permissions, so creating backup and mounting that instead)
 pre-commit:
 ifdef GHE
 ifndef GH_TOKEN
@@ -103,40 +103,42 @@ endif
 	then \
 		bash -c "$${run_cmd}"; \
 	else \
-		cp -r ~/.ssh /tmp && \
+		cp -r ~/{.netrc,.ssh} /tmp && \
 		${CONTAINER_RUNTIME} run -it -v $$(pwd):/mnt \
 			-v /tmp/.ssh:/root/.ssh \
+			-v /tmp/.netrc:/root/.netrc \
 			-e GH_TOKEN \
 			${DOCKER_REGISTRY}/$(IMAGE) \
-			bash -c "chown -R root /root/.ssh && \
-				chgrp -R root /root/.ssh && \
+			bash -c "chown -R root /root/.ssh /root/.netrc && \
+				chgrp -R root /root/.ssh /root/.netrc && \
 				$${run_cmd}"; \
 		exitCode=$$?; \
-		sudo rm -rf /tmp/.ssh; \
+		sudo rm -rf /tmp/.ssh /tmp/.netrc; \
 		exit $${exitCode}; \
 	fi
 
 # pre-commit for non-terraform repos
-# (in container approach, not directly mounting ~/.ssh because we will be changing the permissions, so creating backup and mounting that instead)
+# (in container approach, not directly mounting ~/.ssh or ~/.netrc because we will be changing the permissions, so creating backup and mounting that instead)
 pre-commit-no-terraform:
 	@run_cmd="pre-commit run --all-files" && \
 	if [ "$${NO_CONTAINER}" = "true" ]; \
 	then \
 		bash -c "$${run_cmd}"; \
 	else \
-		cp -r ~/.ssh /tmp && \
+		cp -r ~/{.netrc,.ssh} /tmp && \
 		${CONTAINER_RUNTIME} run -it -v $$(pwd):/mnt \
 			-v /tmp/.ssh:/root/.ssh \
+			-v /tmp/.netrc:/root/.netrc \
 			${DOCKER_REGISTRY}/$(IMAGE) \
-			bash -c "chown -R root /root/.ssh && \
+			bash -c "chown -R root /root/.ssh /root/.netrc && \
 				$${run_cmd}"; \
 		exitCode=$$?; \
-		sudo rm -rf /tmp/.ssh; \
+		sudo rm -rf /tmp/.ssh /tmp/.netrc; \
 		exit $${exitCode}; \
 	fi
 
 # run pre-commit checks against renovate PRs, and commit back any changes to the PR (e.g. doc updates, secrets baseline etc)
-# (in container approach, not directly mounting ~/.ssh because we will be changing the permissions, so creating backup and mounting that instead)
+# (in container approach, not directly mounting ~/.ssh or ~/.netrc because we will be changing the permissions, so creating backup and mounting that instead)
 renovate-sweeper:
     ifndef GH_TOKEN
 	   $(error Error: GH_TOKEN is undefined)
@@ -147,19 +149,20 @@ renovate-sweeper:
 	then \
 		bash -c "$${run_cmd}"; \
 	else \
-		cp -r ~/.ssh /tmp && \
+		cp -r ~/{.netrc,.ssh} /tmp && \
 		${CONTAINER_RUNTIME} run -it -v $$(pwd):/mnt \
 			-v /tmp/.ssh:/root/.ssh \
+			-v /tmp/.netrc:/root/.netrc \
 			-e TRAVIS \
 			-e TRAVIS_PULL_REQUEST \
 			-e TRAVIS_PULL_REQUEST_BRANCH \
 			-e GH_TOKEN \
 			${DOCKER_REGISTRY}/$(IMAGE) \
-			bash -c "chown -R root /root/.ssh && \
-				chgrp -R root /root/.ssh && \
+			bash -c "chown -R root /root/.ssh /root/.netrc && \
+				chgrp -R root /root/.ssh /root/.netrc && \
 				$${run_cmd}"; \
 		exitCode=$$?; \
-		sudo rm -rf /tmp/.ssh; \
+		sudo rm -rf /tmp/.ssh /tmp/.netrc; \
 		exit $${exitCode}; \
 	fi
 


### PR DESCRIPTION
### Description

need to mount netrc file for the git submodule version check hook to work in travis

**Check the relevant boxes:**
- [x] Bug fix (nonbreaking change that fixes an issue)
- [ ] New feature (nonbreaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [ ] CI related update (pipeline, etc.)

### Checklist

- [ ] If relevant, a test for the change has been added or updated as part of this PR.
- [ ] If relevant, documentation for the change has been added or updated as part of this PR.

### Merge

- Merge using "Squash and merge".
- Make sure to use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents. The commit message determines whether a new version of the modules needs to be released, and if so, which semver number to use).
