### PR TITLE
ci: fix the copy command for netrc

### DIFF
--- a/module-assets/Makefile
+++ b/module-assets/Makefile
@@ -103,7 +103,8 @@ endif
 	then \
 		bash -c "$${run_cmd}"; \
 	else \
-		cp -r ~/{.netrc,.ssh} /tmp && \
+		cp -r ~/.ssh /tmp && \
+		cp ~/.netrc /tmp && \
 		${CONTAINER_RUNTIME} run -it -v $$(pwd):/mnt \
 			-v /tmp/.ssh:/root/.ssh \
 			-v /tmp/.netrc:/root/.netrc \
@@ -125,7 +126,8 @@ pre-commit-no-terraform:
 	then \
 		bash -c "$${run_cmd}"; \
 	else \
-		cp -r ~/{.netrc,.ssh} /tmp && \
+		cp -r ~/.ssh /tmp && \
+		cp ~/.netrc /tmp && \
 		${CONTAINER_RUNTIME} run -it -v $$(pwd):/mnt \
 			-v /tmp/.ssh:/root/.ssh \
 			-v /tmp/.netrc:/root/.netrc \
@@ -149,7 +151,8 @@ renovate-sweeper:
 	then \
 		bash -c "$${run_cmd}"; \
 	else \
-		cp -r ~/{.netrc,.ssh} /tmp && \
+		cp -r ~/.ssh /tmp && \
+		cp ~/.netrc /tmp && \
 		${CONTAINER_RUNTIME} run -it -v $$(pwd):/mnt \
 			-v /tmp/.ssh:/root/.ssh \
 			-v /tmp/.netrc:/root/.netrc \


### PR DESCRIPTION
### Description
In https://github.com/terraform-ibm-modules/common-dev-assets/pull/345 we added support to mount the netrc file into the make commands that run pre-commits, since one of the pre-commits now needs it to do a git clone.
The command we used seems to be failing with:
`cp: cannot stat '/home/travis/{.netrc,.ssh}': No such file or directory`
So splitting the command into separate lines

**Check the relevant boxes:**
- [x] Bug fix (nonbreaking change that fixes an issue)
- [ ] New feature (nonbreaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [ ] CI related update (pipeline, etc.)

### Checklist

- [ ] If relevant, a test for the change has been added or updated as part of this PR.
- [ ] If relevant, documentation for the change has been added or updated as part of this PR.

### Merge

- Merge using "Squash and merge".
- Make sure to use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents. The commit message determines whether a new version of the modules needs to be released, and if so, which semver number to use).
