### PR TITLE
fix: add change group ownership for ssh make pre-commit

### DIFF
--- a/module-assets/Makefile
+++ b/module-assets/Makefile
@@ -133,6 +133,7 @@ pre-commit-no-terraform:
 			-v /tmp/.netrc:/root/.netrc \
 			${DOCKER_REGISTRY}/$(IMAGE) \
 			bash -c "chown -R root /root/.ssh /root/.netrc && \
+				chgrp -R root /root/.ssh /root/.netrc && \
 				$${run_cmd}"; \
 		exitCode=$$?; \
 		sudo rm -rf /tmp/.ssh /tmp/.netrc; \


### PR DESCRIPTION
### Description

we need to change group ownership for ssh and netrc files inside pre-commit-no-terraform make cmd

**Check the relevant boxes:**
- [X] Bug fix (nonbreaking change that fixes an issue)
- [ ] New feature (nonbreaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [ ] CI related update (pipeline, etc.)

### Checklist

- [ ] If relevant, a test for the change has been added or updated as part of this PR.
- [ ] If relevant, documentation for the change has been added or updated as part of this PR.

### Merge

- Merge using "Squash and merge".
- Make sure to use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents. The commit message determines whether a new version of the modules needs to be released, and if so, which semver number to use).
