### PR TITLE
ci: update logic in contanerize.sh

### DIFF
--- a/pipeline-assets/contanerize.sh
+++ b/pipeline-assets/contanerize.sh
@@ -14,27 +14,42 @@ export ARTIFACTORY_PASSWORD="$(get_env artifactory-password)"
 # shellcheck disable=SC2155
 export IBMCLOUD_APIKEY="$(get_env ibmcloud-api-key)"
 
+# build the image
 make docker-build || exit_code=$?
-make docker-validate  || exit_code=$?
+if [[ "${exit_code}" -ne 0 ]]; then
+  echo "ERROR: Docker build failed"
+fi
 
-BRANCH=$(get_env "BRANCH")
+# validate image (only if the docker build passed)
+if [[ "${exit_code}" -eq 0 ]]; then
+  make docker-validate || exit_code=$?
+  if [[ "${exit_code}" -ne 0 ]]; then
+    echo "ERROR: Docker image validation failed"
+  fi
+fi
 
-if [ "${BRANCH^^}" != "MASTER" ] && [ "${BRANCH^^}" != "MAIN" ]; then
-  # Grep explanation https://stackoverflow.com/a/22727242
-  PR_NUMBER=$(get_env "PR_URL" | grep -o '[^/]*$')
-  IMAGE_NAME=$(get_env "IMAGE_NAME")
-  IMAGE_TAG="PR-${PR_NUMBER}"
-  make docker-push IMAGE_TAG="${IMAGE_TAG}"
-  REGISTRY="$(get_env 'DEV_REPO'  | cut -f1 -d/  )"
-  NAMESPACE="$(get_env 'DEV_REPO' | cut -f2 -d/ )"
+# push image to ICR and fetch VA scan result (only if docker build + validation passed)
+if [[ "${exit_code}" -eq 0 ]]; then
+  # only needed for PR pipeline - CI pipeline has its own VA scan step
+  BRANCH=$(get_env "BRANCH")
+  if [ "${BRANCH^^}" != "MASTER" ] && [ "${BRANCH^^}" != "MAIN" ]; then
+    # Grep explanation https://stackoverflow.com/a/22727242
+    PR_NUMBER=$(get_env "PR_URL" | grep -o '[^/]*$')
+    IMAGE_NAME=$(get_env "IMAGE_NAME")
+    IMAGE_TAG="PR-${PR_NUMBER}"
+    make docker-push IMAGE_TAG="${IMAGE_TAG}"
+    REGISTRY="$(get_env 'DEV_REPO'  | cut -f1 -d/  )"
+    NAMESPACE="$(get_env 'DEV_REPO' | cut -f2 -d/ )"
 
-  ./common-dev-assets/pipeline-assets/image_vuln_scan.sh "${REGISTRY}" "${NAMESPACE}" "${IMAGE_NAME}" "${IMAGE_TAG}" "${IBMCLOUD_APIKEY}" false  || exit_code=$?
-
+    ./common-dev-assets/pipeline-assets/image_vuln_scan.sh "${REGISTRY}" "${NAMESPACE}" "${IMAGE_NAME}" "${IMAGE_TAG}" "${IBMCLOUD_APIKEY}" false  || exit_code=$?
+  fi
+else
+  echo "Skipping push to ICR and VA scan due to earlier failure"
 fi
 
 # save status for new evidence collection
 set_env status "success"
-if [ "$exit_code" != "0" ]; then
+if [[ "${exit_code}" -ne 0 ]]; then
   set_env status "failure"
 fi
 


### PR DESCRIPTION
### Description

Currently if the docker build command fails, it will proceed to try validate, push to ICR and VA scan against an image that does not exist. This means it can be hard to actually identify the root cause to a failing pipeline, as there will be a lot of log noise like this:

```
-- VALIDATING LOCALLY BUILT DOCKER IMAGE --
docker run --tty ubi8-squid-proxy whoami
Unable to find image 'ubi8-squid-proxy:latest' locally
docker: Error response from daemon: pull access denied for ubi8-squid-proxy, repository does not exist or may require 'docker login': denied: requested access to the resource is denied.
See 'docker run --help'.
make: *** [Makefile:69: docker-validate] Error 125
                   
API endpoint:      https://cloud.ibm.com/
Region:            us-east
User:              [GoldenEye.Operations@ibm.com](mailto:GoldenEye.Operations@ibm.com)
Account:           GoldenEye GoldenEye Operations's Account (9f9af00a96104f49b6509aa715f9d6a5) <-> 2325206
Resource group:    No resource group targeted, use 'ibmcloud target -g RESOURCE_GROUP'
CF API endpoint:   
Org:               
Space:             
ibmcloud cr region-set global
The region is set to 'global', the registry is '[icr.io](http://icr.io/)'.

OK
ibmcloud cr login
Logging 'docker' in to '[icr.io](http://icr.io/)'...
Logged in to '[icr.io](http://icr.io/)'.

OK
Error response from daemon: No such image: ubi8-squid-proxy:latest
The push refers to repository [[icr.io/goldeneye_images_preprod/ubi8-squid-proxy](http://icr.io/goldeneye_images_preprod/ubi8-squid-proxy)]
An image does not exist locally with the tag: [icr.io/goldeneye_images_preprod/ubi8-squid-proxy](http://icr.io/goldeneye_images_preprod/ubi8-squid-proxy)
make: *** [Makefile:58: docker-push] Error 1
Image not scanned yet
BXNVA0033E: [icr.io/goldeneye_images_preprod/ubi8-squid-proxy:PR-226](http://icr.io/goldeneye_images_preprod/ubi8-squid-proxy:PR-226) does not exist in this namespace. To list the images in your account, run the 'ibmcloud cr image-list' command.

 === Execution of custom script for stage 'test' finished. Exit Code: '1'. ===
```

The updates in this PR means if the docker build fails, it wont try validate or push to ICR or VA scan.
If the validate fails, it wont try to push to ICR or VA scan.
I purposely am not using `set -e` because the `set_env status` always needs to run to save status for new evidence collection.

#### No release required

- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [x] CI-related update (pipeline, etc.)
- [ ] Other changes that don't affect Terraform code

#### Release required

- [ ] Bug fix (patch release (`x.x.X`): Change that fixes an issue and is compatible with earlier versions)
- [ ] New feature (minor release (`x.X.x`): Change that adds functionality and is compatible with earlier versions)
- [ ] Breaking change (major release (`X.x.x`): Change that is likely incompatible with previous versions)

##### Release notes content

Replace this text with information that users need to know about the bug fixes, features, and breaking changes. This information helps the merger write the commit message that is published in the release notes for the module.

---

### Checklist for reviewers

- [ ] The PR references a GitHub issue.
- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### Merge actions for mergers

- Merge by using "Squash and merge".
- Use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents and any release notes provided by the PR author.

    The commit message determines whether a new version of the module is needed, and if so, which semver increment to use (major, minor, or patch).
