### PR TITLE
ci: pull tf docs from github

### DIFF
--- a/module-assets/ci/install-deps.sh
+++ b/module-assets/ci/install-deps.sh
@@ -245,7 +245,7 @@ INSTALLED_TERRADOCS_VERSION="$(terraform-docs --version | head -1 | cut -d' ' -f
 set -e
 if [[ "$TERRAFORM_DOCS_VERSION" != "$INSTALLED_TERRADOCS_VERSION" ]]; then
   FILE_NAME="terraform-docs-${TERRAFORM_DOCS_VERSION}-${OS}-amd64.tar.gz"
-  URL="https://terraform-docs.io/dl/${TERRAFORM_DOCS_VERSION}"
+  URL="https://github.com/terraform-docs/terraform-docs/releases/download/${TERRAFORM_DOCS_VERSION}"
   SUMFILE="terraform-docs-${TERRAFORM_DOCS_VERSION}.sha256sum"
   TMP_DIR=$(mktemp -d /tmp/${BINARY}-XXXXX)
 


### PR DESCRIPTION
### Description

terraform-docs.io seems to be down, so updating to pull from github instead

#### No release required

- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [x] CI-related update (pipeline, etc.)
- [ ] Other changes that don't affect Terraform code

#### Release required

- [ ] Bug fix (patch release (`x.x.X`): Change that fixes an issue and is compatible with earlier versions)
- [ ] New feature (minor release (`x.X.x`): Change that adds functionality and is compatible with earlier versions)
- [ ] Breaking change (major release (`X.x.x`): Change that is likely incompatible with previous versions)

##### Release notes content

Replace this text with information that users need to know about the bug fixes, features, and breaking changes. This information helps the merger write the commit message that is published in the release notes for the module.

---

### Checklist for reviewers

- [ ] The PR references a GitHub issue.
- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### Merge actions for mergers

- Merge by using "Squash and merge".
- Use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents and any release notes provided by the PR author.

    The commit message determines whether a new version of the module is needed, and if so, which semver increment to use (major, minor, or patch).
