### PR TITLE
fix: Makefile changes to support secure git and read-only volume mounts

### DIFF
--- a/module-assets/Makefile
+++ b/module-assets/Makefile
@@ -112,7 +112,7 @@ endif
 			${DOCKER_REGISTRY}/$(IMAGE) \
 			bash -c "chown -R root /root/.ssh /root/.netrc && \
 				chgrp -R root /root/.ssh /root/.netrc && \
-				chown -R \$$(id -u):\$$(id -g) \$$PWD && \
+				git config --global --add safe.directory \$$PWD && \
 				$${run_cmd}"; \
 		exitCode=$$?; \
 		sudo rm -rf /tmp/.ssh /tmp/.netrc; \
@@ -135,7 +135,7 @@ pre-commit-no-terraform:
 			${DOCKER_REGISTRY}/$(IMAGE) \
 			bash -c "chown -R root /root/.ssh /root/.netrc && \
 				chgrp -R root /root/.ssh /root/.netrc && \
-				chown -R \$$(id -u):\$$(id -g) \$$PWD && \
+				git config --global --add safe.directory \$$PWD && \
 				$${run_cmd}"; \
 		exitCode=$$?; \
 		sudo rm -rf /tmp/.ssh /tmp/.netrc; \
@@ -166,7 +166,7 @@ renovate-sweeper:
 			${DOCKER_REGISTRY}/$(IMAGE) \
 			bash -c "chown -R root /root/.ssh /root/.netrc && \
 				chgrp -R root /root/.ssh /root/.netrc && \
-				chown -R \$$(id -u):\$$(id -g) \$$PWD && \
+				git config --global --add safe.directory \$$PWD && \
 				$${run_cmd}"; \
 		exitCode=$$?; \
 		sudo rm -rf /tmp/.ssh /tmp/.netrc; \
@@ -207,7 +207,7 @@ endif
 			${DOCKER_REGISTRY}/$(IMAGE) \
 			bash -c "chown -R root /root/.ssh && \
 				chgrp -R root /root/.ssh && \
-				chown -R \$$(id -u):\$$(id -g) \$$PWD && \
+				git config --global --add safe.directory \$$PWD && \
 				$${run_cmd}"; \
 		exitCode=$$?; \
 		sudo rm -rf /tmp/.ssh; \


### PR DESCRIPTION
### Description

Changes to common Makefile and docker usage that will allow `secure-git` to function properly when using read-only volume mounts.
* Replaced the `chown` of internal docker mounts to instead use `git config --add safe.directory`

### Types of changes in this PR

#### No release required

- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [ ] CI-related update (pipeline, etc.)
- [ ] Other changes that don't affect Terraform code

#### Release required

- [x] Bug fix (patch release (`x.x.X`): Change that fixes an issue and is compatible with earlier versions)
- [ ] New feature (minor release (`x.X.x`): Change that adds functionality and is compatible with earlier versions)
- [ ] Breaking change (major release (`X.x.x`): Change that is likely incompatible with previous versions)

##### Release notes content

Changes to common Makefile and docker usage that will allow `secure-git` to function properly when using read-only volume mounts.

---

### Checklist for reviewers

- [ ] The PR references a GitHub issue.
- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### Merge actions for mergers

- Merge by using "Squash and merge".
- Use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents and any release notes provided by the PR author.

    The commit message determines whether a new version of the module is needed, and if so, which semver increment to use (major, minor, or patch).
