### PR TITLE
docs: add info about ref arch

### DIFF
--- a/module-assets/ci/module-template-automation/.terraform-docs-config-template-module.yaml
+++ b/module-assets/ci/module-template-automation/.terraform-docs-config-template-module.yaml
@@ -131,6 +131,8 @@ content: |-
     <!--
     Add links to any reference architectures for this module.
     (Usually in the `/reference-architectures` directory.)
+    See "Reference architecture" in Authoring Guidelines in the public documentation at
+    https://terraform-ibm-modules.github.io/documentation/#/implementation-guidelines?id=reference-architecture
     -->
     {{- end }}
 


### PR DESCRIPTION
### Description

Add a link to the public docs about the reference architecture. Adding this because the template is no longer in the module template.

GitHub issue: https://github.com/terraform-ibm-modules/terraform-ibm-issue-tracker/issues/54

### Types of changes in this PR

#### No release required

- [ ] Examples or tests (addition or updates of examples or tests)
- [x] Documentation update
- [ ] CI-related update (pipeline, etc.)
- [ ] Other changes that don't affect Terraform code

#### Release required

- [ ] Bug fix (patch release (`x.x.X`): Change that fixes an issue and is compatible with earlier versions)
- [ ] New feature (minor release (`x.X.x`): Change that adds functionality and is compatible with earlier versions)
- [ ] Breaking change (major release (`X.x.x`): Change that is likely incompatible with previous versions)

##### Release notes content

Replace this text with information that users need to know about the bug fixes, features, and breaking changes. This information helps the merger write the commit message that is published in the release notes for the module.

---

### Checklist for reviewers

- [ ] The PR references a GitHub issue.
- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### Merge actions for mergers

- Merge by using "Squash and merge".
- Use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents and any release notes provided by the PR author.

    The commit message determines whether a new version of the module is needed, and if so, which semver increment to use (major, minor, or patch).
