### PR TITLE
ci: fix the repo setting config

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -8,10 +8,12 @@
 _extends: repo-settings
 
 # unique to this repo
-required_status_checks:
-  strict: true
-  contexts:
-    - "CI_Pipeline"
+branches:
+  - name: main
+    protection:
+      required_status_checks:
+        contexts:
+          - "CI_Pipeline"
 
 repository:
   # See https://terraform-ibm-modules.github.io/documentation/#/implementation-guidelines?id=module-names-and-descriptions


### PR DESCRIPTION
### Description

I noticed that our main branch protection rule in this repo was not requiring the `CI_Pipeline` status check to complete before being able to merge. The config in settings.yml was incorrect. The code in this PR should fix it

### Types of changes in this PR

#### No release required

- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [x] CI-related update (pipeline, etc.)
- [x] Other changes that don't affect Terraform code

#### Release required

- [ ] Bug fix (patch release (`x.x.X`): Change that fixes an issue and is compatible with earlier versions)
- [ ] New feature (minor release (`x.X.x`): Change that adds functionality and is compatible with earlier versions)
- [ ] Breaking change (major release (`X.x.x`): Change that is likely incompatible with previous versions)

##### Release notes content

Replace this text with information that users need to know about the bug fixes, features, and breaking changes. This information helps the merger write the commit message that is published in the release notes for the module.

---

### Checklist for reviewers

- [ ] The PR references a GitHub issue.
- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### Merge actions for mergers

- Merge by using "Squash and merge".
- Use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents and any release notes provided by the PR author.

    The commit message determines whether a new version of the module is needed, and if so, which semver increment to use (major, minor, or patch).
