### PR TITLE
ci: allow up to 3 renovate PRs to exist at any given time

### DIFF
--- a/commonRenovateConfig.json
+++ b/commonRenovateConfig.json
@@ -5,7 +5,7 @@
     ":disableDependencyDashboard"
   ],
   "cloneSubmodules": false,
-  "prConcurrentLimit": 1,
+  "prConcurrentLimit": 3,
   "branchConcurrentLimit": 0,
   "automerge": false,
   "force": {


### PR DESCRIPTION
### Description

By having `prConcurrentLimit` set to `1` we are finding that things like the common-dev-assets git submodule and the test wrapper version can remain on very old versions because renovate is set up to priortise creating updates for terraform dependencies first. By setting it to `3` it should at least allow terraform dependencies, git submodule and go dependencies to be updated

### Types of changes in this PR

#### No release required

- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [x] CI-related update (pipeline, etc.)
- [ ] Other changes that don't affect Terraform code

#### Release required

- [ ] Bug fix (patch release (`x.x.X`): Change that fixes an issue and is compatible with earlier versions)
- [ ] New feature (minor release (`x.X.x`): Change that adds functionality and is compatible with earlier versions)
- [ ] Breaking change (major release (`X.x.x`): Change that is likely incompatible with previous versions)

##### Release notes content

Replace this text with information that users need to know about the bug fixes, features, and breaking changes. This information helps the merger write the commit message that is published in the release notes for the module.

---

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### Merge actions for mergers

- Merge by using "Squash and merge".
- Use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents and any release notes provided by the PR author.

    The commit message determines whether a new version of the module is needed, and if so, which semver increment to use (major, minor, or patch).
