### PR TITLE
ci: enable rule to bump terraform required_version

### DIFF
--- a/commonRenovateConfig.json
+++ b/commonRenovateConfig.json
@@ -46,7 +46,7 @@
       "semanticCommitType": "ci"
     },
     {
-      "description": "Use the widen range stretegy to allow us to lock into exact supported terraform range since terraform can release breaking changes in minor version releases.",
+      "description": "Use the widen range strategy to allow us to lock into exact supported terraform range since terraform can release breaking changes in minor version releases.",
       "matchManagers": ["terraform"],
       "matchDepTypes": ["required_version"],
       "enabled": true,

--- a/commonRenovateConfig.json
+++ b/commonRenovateConfig.json
@@ -46,10 +46,11 @@
       "semanticCommitType": "ci"
     },
     {
-      "description": "Disable updates of the terraform version so it stays at >= 1.0.0",
+      "description": "Use the widen range stretegy to allow us to lock into exact supported terraform range since terraform can release breaking changes in minor version releases.",
       "matchManagers": ["terraform"],
       "matchDepTypes": ["required_version"],
-      "enabled": false
+      "enabled": true,
+      "rangeStrategy": "widen"
     },
     {
       "description": "Disable terraform provider updates by default. To enable, set enable to true below and renovate will priortise bumping this. We only need to bump this version to consume required bug fixes and/or new provider features.",


### PR DESCRIPTION
### Description

- For modules that currently have `required_version = ">= 1.0.0"` this rule will not do anything.
- For modules that have `required_version = ">= 1.2, <= 1.3"` this rule will widen the range like so:
![image](https://user-images.githubusercontent.com/29608224/227495537-7bc139fb-73ce-4016-9da3-db04a383289a.png)


### Types of changes in this PR

#### No release required

- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [x] CI-related update (pipeline, etc.)
- [ ] Other changes that don't affect Terraform code

#### Release required

- [ ] Bug fix (patch release (`x.x.X`): Change that fixes an issue and is compatible with earlier versions)
- [ ] New feature (minor release (`x.X.x`): Change that adds functionality and is compatible with earlier versions)
- [ ] Breaking change (major release (`X.x.x`): Change that is likely incompatible with previous versions)

##### Release notes content

Replace this text with information that users need to know about the bug fixes, features, and breaking changes. This information helps the merger write the commit message that is published in the release notes for the module.

---

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### Merge actions for mergers

- Merge by using "Squash and merge".
- Use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents and any release notes provided by the PR author.

    The commit message determines whether a new version of the module is needed, and if so, which semver increment to use (major, minor, or patch).
