### PR TITLE
fix: change order as ssh key is conflicting

### DIFF
--- a/common-go-assets/cloudinfo-region-power-prefs.yaml
+++ b/common-go-assets/cloudinfo-region-power-prefs.yaml
@@ -26,7 +26,6 @@
 - name: syd05
   useForTest: true
   testPriority: 9
-
   # not yet supported by terraform-ibm-powervs-infrastructure module
 - name: wdc06
   useForTest: false

--- a/common-go-assets/cloudinfo-region-power-prefs.yaml
+++ b/common-go-assets/cloudinfo-region-power-prefs.yaml
@@ -2,7 +2,7 @@
 - name: syd04
   useForTest: true
   testPriority: 1
-- name: syd05
+- name: tok04
   useForTest: true
   testPriority: 2
 - name: sao01
@@ -11,10 +11,10 @@
 - name: eu-de-1
   useForTest: true
   testPriority: 4
-- name: eu-de-2
+- name: lon04
   useForTest: true
   testPriority: 5
-- name: lon04
+- name: eu-de-2
   useForTest: true
   testPriority: 6
 - name: lon06
@@ -23,9 +23,10 @@
 - name: osa21
   useForTest: true
   testPriority: 8
-- name: tok04
+- name: syd05
   useForTest: true
   testPriority: 9
+
   # not yet supported by terraform-ibm-powervs-infrastructure module
 - name: wdc06
   useForTest: false


### PR DESCRIPTION
### Description

as the test are creating deployments in same region because of priority. ssh key causes a problem
for example, syd04 and syd05 powervs zones are mapped to au-syd region on VPC side. Test is picking up the first 2 regions.
this creates 2 slzs in au-syd. This causes a problem, beacause of duplicate ssh key created by default and upgrade example

### Types of changes in this PR

#### No release required

- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [x] CI-related update (pipeline, etc.)
- [ ] Other changes that don't affect Terraform code

#### Release required

- [ ] Bug fix (patch release (`x.x.X`): Change that fixes an issue and is compatible with earlier versions)
- [ ] New feature (minor release (`x.X.x`): Change that adds functionality and is compatible with earlier versions)
- [ ] Breaking change (major release (`X.x.x`): Change that is likely incompatible with previous versions)

##### Release notes content

Replace this text with information that users need to know about the bug fixes, features, and breaking changes. This information helps the merger write the commit message that is published in the release notes for the module.

---

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### Merge actions for mergers

- Merge by using "Squash and merge".
- Use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents and any release notes provided by the PR author.

    The commit message determines whether a new version of the module is needed, and if so, which semver increment to use (major, minor, or patch).
