### PR TITLE
Revert "ci: update icd region list"

### DIFF
--- a/common-go-assets/icd-region-prefs.yaml
+++ b/common-go-assets/icd-region-prefs.yaml
@@ -1,13 +1,10 @@
-# BYOK for backups is available only in us-south, us-east, and eu-de.
+# BYOK for backups is available only in us-south and eu-de.
 # The ICD instance must be in the same region as the Key Protect one.
 # Doc: https://cloud.ibm.com/docs/cloud-databases?topic=cloud-databases-key-protect&interface=ui#key-byok
 ---
 - name: eu-de
   useForTest: true
   testPriority: 1
-- name: us-east
-  useForTest: true
-  testPriority: 2
 - name: us-south
   useForTest: true
-  testPriority: 3
+  testPriority: 2


### PR DESCRIPTION
Reverts terraform-ibm-modules/common-dev-assets#611

It seems `us-east` does not work (even though it says it is supported in the docs). Reverting for now. Will reach out to ICD to get clarification. 