### PR TITLE
[renovate] Set prConcurrentLimit to 1

### DIFF
--- a/commonRenovateConfig.json
+++ b/commonRenovateConfig.json
@@ -5,7 +5,7 @@
     ":disableDependencyDashboard"
   ],
   "cloneSubmodules": false,
-  "prConcurrentLimit": 3,
+  "prConcurrentLimit": 1,
   "branchConcurrentLimit": 0,
   "automerge": false,
   "force": {


### PR DESCRIPTION
### Description

We haven't run renovate in a long time, so I'm setting `prConcurrentLimit` to `1` so when I do run it, only 1 PR will be allowed in each repo at any given time, meaning we won't trigger a load of parallel tests. Once we roll out triggering pipeline with comments, we can set this to any number, but only leave a comment in 1 PR

### Types of changes in this PR

#### Changes that affect the core Terraform module or submodules
- [ ] Bug fix
- [ ] New feature
- [ ] Dependency update

#### Changes that don't affect the core Terraform module or submodules
- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [x] CI-related update (pipeline, etc.)
- [ ] Other

#### Release required?
Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning).

- [x] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version. 

Your notes helps the merger write the commit message for the PR that is published in the release notes for the module.

---

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### Merge actions for mergers

- Use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents and any release notes provided by the PR author. The commit message determines whether a new version of the module is needed, and if so, which semver increment to use (major, minor, or patch).
- Merge by using "Squash and merge".
