### PR TITLE
Further updates to commonRenovateConfig.json for "postUpgradeTasks"

### DIFF
--- a/commonRenovateConfig.json
+++ b/commonRenovateConfig.json
@@ -25,7 +25,7 @@
   ],
   "postUpdateOptions": ["gomodTidy", "gomodUpdateImportPaths"],
   "postUpgradeTasks": {
-    "commands": ["pre-commit run --all-files || true"],
+    "commands": ["make dependency-install-darwin-linux", "pre-commit run --all-files || true"],
     "fileFilters": ["**/**"],
     "executionMode": "update"
   },

--- a/commonRenovateConfig.json
+++ b/commonRenovateConfig.json
@@ -25,7 +25,7 @@
   ],
   "postUpdateOptions": ["gomodTidy", "gomodUpdateImportPaths"],
   "postUpgradeTasks": {
-    "commands": ["pre-commit install && pre-commit run --all-files || true"],
+    "commands": ["pre-commit run --all-files || true"],
     "fileFilters": ["**/**"],
     "executionMode": "update"
   },


### PR DESCRIPTION
In order to run pre-commit hooks, we need to install dependencies into the dependency updater image