### PR TITLE
Add HPCS ids to permanent resources

### DIFF
--- a/common-go-assets/common-permanent-resources.yaml
+++ b/common-go-assets/common-permanent-resources.yaml
@@ -25,8 +25,10 @@ dedicatedHostCrn: "crn:v1:bluemix:public:cloudantnosqldb:us-south:a/abac0df06b64
 
 # HyperProtect Crypto Instances and Root Keys
 hpcs_east: "bc07f975-0b8c-47a3-9c10-fffa60f483f1"
+hpcs_east_id: "crn:v1:bluemix:public:hs-crypto:us-east:a/abac0df06b644a9cabc6e44f55b3880e:bc07f975-0b8c-47a3-9c10-fffa60f483f1::"
 hpcs_east_root_key_crn: "crn:v1:bluemix:public:hs-crypto:us-east:a/abac0df06b644a9cabc6e44f55b3880e:bc07f975-0b8c-47a3-9c10-fffa60f483f1:key:ab15dcaf-39e5-4a6b-b97a-8c807c6b9145"
 hpcs_south: "e6dce284-e80f-46e1-a3c1-830f7adff7a9"
+hpcs_south_id: "crn:v1:bluemix:public:hs-crypto:us-south:a/abac0df06b644a9cabc6e44f55b3880e:e6dce284-e80f-46e1-a3c1-830f7adff7a9::"
 hpcs_south_root_key_crn: "crn:v1:bluemix:public:hs-crypto:us-south:a/abac0df06b644a9cabc6e44f55b3880e:e6dce284-e80f-46e1-a3c1-830f7adff7a9:key:1368d2eb-3ed0-4a8b-b09c-2155895f01ea"
 
 # vpc crn from GE staging account for transit gateway crossaccount connection tests


### PR DESCRIPTION
### Description

COS will require ID rather than GUID moving forward to set up authorization policies. This change adds new permanent
properties that are so far unused.

### Types of changes in this PR

#### Changes that affect the core Terraform module or submodules
- [ ] Bug fix
- [] New feature
- [ ] Dependency update

#### Changes that don't affect the core Terraform module or submodules
- [x] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [ ] CI-related update (pipeline, etc.)
- [ ] Other

#### Release required?
Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning).

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

No changes to any existing code or resources. Added IDs for both us-south and us-east HPCS services.

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### Merge actions for mergers

- Use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents and any release notes provided by the PR author. The commit message determines whether a new version of the module is needed, and if so, which semver increment to use (major, minor, or patch).
- Merge by using "Squash and merge".
