### PR TITLE
test: remove japan regions from test prefs

### DIFF
--- a/common-go-assets/cloudinfo-region-secmgr-prefs.yaml
+++ b/common-go-assets/cloudinfo-region-secmgr-prefs.yaml
@@ -9,10 +9,10 @@
   useForTest: true
   testPriority: 3
 - name: jp-osa
-  useForTest: true
+  useForTest: false
   testPriority: 8
 - name: jp-tok
-  useForTest: true
+  useForTest: false
   testPriority: 9
 - name: eu-de
   useForTest: true

--- a/common-go-assets/cloudinfo-region-secmgr-prefs.yaml
+++ b/common-go-assets/cloudinfo-region-secmgr-prefs.yaml
@@ -10,19 +10,19 @@
   testPriority: 3
 - name: jp-osa
   useForTest: true
-  testPriority: 4
+  testPriority: 8
 - name: jp-tok
   useForTest: true
-  testPriority: 5
+  testPriority: 9
 - name: eu-de
   useForTest: true
-  testPriority: 6
+  testPriority: 4
 - name: eu-gb
   useForTest: true
-  testPriority: 7
+  testPriority: 5
 - name: us-east
   useForTest: true
-  testPriority: 8
+  testPriority: 6
 - name: us-south
   useForTest: true
-  testPriority: 9
+  testPriority: 7

--- a/common-go-assets/cloudinfo-region-vpc-gen2-prefs.yaml
+++ b/common-go-assets/cloudinfo-region-vpc-gen2-prefs.yaml
@@ -4,25 +4,25 @@
   testPriority: 1
 - name: br-sao
   useForTest: true
-  testPriority: 4
+  testPriority: 3
 - name: ca-tor
   useForTest: true
   testPriority: 2
 - name: eu-de
   useForTest: true
-  testPriority: 6
+  testPriority: 4
 - name: eu-gb
   useForTest: true
-  testPriority: 7
+  testPriority: 5
 - name: jp-osa
   useForTest: true
-  testPriority: 3
+  testPriority: 8
 - name: jp-tok
   useForTest: true
-  testPriority: 5
+  testPriority: 9
 - name: us-east
   useForTest: true
-  testPriority: 8
+  testPriority: 6
 - name: us-south
   useForTest: true
-  testPriority: 9
+  testPriority: 7

--- a/common-go-assets/cloudinfo-region-vpc-gen2-prefs.yaml
+++ b/common-go-assets/cloudinfo-region-vpc-gen2-prefs.yaml
@@ -15,10 +15,10 @@
   useForTest: true
   testPriority: 5
 - name: jp-osa
-  useForTest: true
+  useForTest: false
   testPriority: 8
 - name: jp-tok
-  useForTest: true
+  useForTest: false
   testPriority: 9
 - name: us-east
   useForTest: true


### PR DESCRIPTION
### Description

At the request of management in IBM, remove all Japan regions (tok, osa) from IBM Cloud test run preferences.

We will be notified by management when we should add them back into test rotation.

### Release required?
Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning).

- [x] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### Merge actions for mergers

- Use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents and any release notes provided by the PR author. The commit message determines whether a new version of the module is needed, and if so, which semver increment to use (major, minor, or patch).
- Merge by using "Squash and merge".
