### PR TITLE
fix: enable japan regions for testing

### DIFF
--- a/common-go-assets/cloudinfo-region-secmgr-prefs.yaml
+++ b/common-go-assets/cloudinfo-region-secmgr-prefs.yaml
@@ -9,10 +9,10 @@
   useForTest: true
   testPriority: 3
 - name: jp-osa
-  useForTest: false
+  useForTest: true
   testPriority: 8
 - name: jp-tok
-  useForTest: false
+  useForTest: true
   testPriority: 9
 - name: eu-de
   useForTest: true

--- a/common-go-assets/cloudinfo-region-vpc-gen2-prefs.yaml
+++ b/common-go-assets/cloudinfo-region-vpc-gen2-prefs.yaml
@@ -15,10 +15,10 @@
   useForTest: true
   testPriority: 5
 - name: jp-osa
-  useForTest: false
+  useForTest: true
   testPriority: 8
 - name: jp-tok
-  useForTest: false
+  useForTest: true
   testPriority: 9
 - name: us-east
   useForTest: true


### PR DESCRIPTION
### Description

Enable Japan regions for testing in the `common-go-assets` test region configurations.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### Merge actions for mergers

- When merging, use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents and any release notes provided by the PR author. The commit message determines whether a new version of the module is needed, and if so, which semver increment to use (major, minor, or patch).
- Merge by using "Squash and merge".
