### PR TITLE
feat: add hook to upgrade terraform inside examples

### DIFF
--- a/module-assets/.pre-commit-config.yaml
+++ b/module-assets/.pre-commit-config.yaml
@@ -16,6 +16,13 @@ repos:
       require_serial: true
       pass_filenames: false
       description: This hook ensures that a file named LICENSE exists for any repo (on github.com) which contains .tf files in the root directory of the repo
+    - id: tf-upgrade
+      name: Upgrade terraform for each example
+      description: This hook upgrades terraform for each example in a case that .terraform folder inside example exists
+      entry: ci/tf-upgrade.sh
+      language: script
+      pass_filenames: false
+      files: ^examples/
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.5.0
   hooks:

--- a/module-assets/ci/tf-upgrade.sh
+++ b/module-assets/ci/tf-upgrade.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+
+BASE_DIR=$(pwd)
+search_dir=./examples
+# run code for each example
+for entry in "$search_dir"/*
+do
+    cd $entry
+    TERRAFORM_DIR=.terraform
+    # if .terraform folder exists then run terraform upgrade
+    if [ -d "$TERRAFORM_DIR" ]; then
+        terraform init -upgrade
+    fi
+    cd $BASE_DIR
+done

--- a/module-assets/ci/tf-upgrade.sh
+++ b/module-assets/ci/tf-upgrade.sh
@@ -2,15 +2,15 @@
 set -e
 
 BASE_DIR=$(pwd)
-search_dir=./examples
+examples_dir=./examples
 # run code for each example
-for entry in "$search_dir"/*
+for example in "$examples_dir"/*
 do
-    cd $entry
+    cd "$example"
     TERRAFORM_DIR=.terraform
     # if .terraform folder exists then run terraform upgrade
     if [ -d "$TERRAFORM_DIR" ]; then
         terraform init -upgrade
     fi
-    cd $BASE_DIR
+    cd "$BASE_DIR"
 done


### PR DESCRIPTION
### Description

`terraform_validate` pre-commit fails in a case that examples has old terraform modules. To prevent this, we introduce a hook, which will upgrade terraform modules in a case they exists inside each example.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
