### PR TITLE
remove terraform-config-inspect hook

### DIFF
--- a/module-assets/.pre-commit-config.yaml
+++ b/module-assets/.pre-commit-config.yaml
@@ -147,13 +147,6 @@ repos:
       language: python
       files: "README.md"
       pass_filenames: false
-    - id: terraform-config-inspect
-      name: Generate terraform module metadata
-      description: Extracting high-level metadata about Terraform modules
-      entry: python3 ci/terraformConfigInspect.py
-      language: python
-      files: '\.tf'
-      pass_filenames: false
     - id: go-mod-module-repository
       name: Add module repository to go.mod
       description: Adding module repository to go.mod file

--- a/module-assets/ci/install-deps.sh
+++ b/module-assets/ci/install-deps.sh
@@ -518,28 +518,6 @@ if [[ "$OC_VERSION" != "$INSTALLED_OC_VERSION" ]]; then
 else
   echo "${BINARY} cli ${OC_VERSION} already installed - skipping install"
 fi
-#######################################
-# terraform config inspect
-#######################################
-
- # renovate: datasource=github-releases depName=IBM-Cloud/terraform-config-inspect
-TERRAFORM_CONFIG_INSPECT_VERSION=v1.0.0-beta4
-# Not possible to check the version of this yet https://github.com/hashicorp/terraform-config-inspect/issues/88
-TERRAFORM_CONFIG_INSPECT_VERSION_NUMBER="${TERRAFORM_CONFIG_INSPECT_VERSION:1}"
-BINARY=terraform-config-inspect
-FILE_NAME="terraform-config-inspect_${TERRAFORM_CONFIG_INSPECT_VERSION_NUMBER}_${OS}_amd64.zip"
-URL="https://github.com/IBM-Cloud/terraform-config-inspect/releases/download/${TERRAFORM_CONFIG_INSPECT_VERSION}"
-SUMFILE="terraform-config-inspect_${TERRAFORM_CONFIG_INSPECT_VERSION_NUMBER}_checksums.txt"
-TMP_DIR=$(mktemp -d /tmp/${BINARY}-XXXXX)
-
-echo
-echo "-- Installing ${BINARY} ${TERRAFORM_CONFIG_INSPECT_VERSION}..."
-
-download ${BINARY} ${TERRAFORM_CONFIG_INSPECT_VERSION} ${URL} "${FILE_NAME}" "${SUMFILE}" "${TMP_DIR}"
-verify "${FILE_NAME}" "${SUMFILE}" "${TMP_DIR}"
-unzip "${TMP_DIR}/${FILE_NAME}" -d "${TMP_DIR}" > /dev/null
-copy_replace_binary ${BINARY} "${TMP_DIR}"
-clean "${TMP_DIR}"
 
 #######################################
 # jq


### PR DESCRIPTION
### Description

- remove terraform-config-inspect hook
- no longer install the tool as a dependency

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
