### PR TITLE
add extra curl flags to webhook trigger in trigger-catalog-onboarding-pipeline.sh

### DIFF
--- a/module-assets/ci/run-tests.sh
+++ b/module-assets/ci/run-tests.sh
@@ -79,7 +79,8 @@ if [ ${IS_PR} == true ]; then
                          "pvs.preset.json"
                          ".fileignore"
                          "cra-config.yaml"
-                         "LICENSE")
+                         "LICENSE"
+                         ".catalog-onboard-pipeline.yaml")
 
   # Determine all files being changed in the PR, and add it to array
   changed_files="$(git diff --name-only "${TARGET_BRANCH}..HEAD" --)"

--- a/module-assets/ci/trigger-catalog-onboarding-pipeline.sh
+++ b/module-assets/ci/trigger-catalog-onboarding-pipeline.sh
@@ -124,7 +124,7 @@ for offering in "${offerings_array[@]}"; do
     # Trigger pipeline
     echo
     echo "Kicking off tekton pipeline for ${offering} .."
-    curl -X POST \
+    curl -fLsS -X POST \
       "$CATALOG_TEKTON_WEBHOOK_URL" \
       -H "Content-Type: application/json" \
       -H "token: ${CATALOG_TEKTON_WEBHOOK_TOKEN}" \


### PR DESCRIPTION
### Description

- add extra curl flags to webhook trigger in trigger-catalog-onboarding-pipeline.sh - without the flags, the command can fail silently 
- add `.catalog-onboard-pipeline.yaml` to the ignore array so tests will not run if a PR runs to only update this file

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
