### PR TITLE
fix: migrate to v4 VA image report api

### DIFF
--- a/pipeline-assets/image_vuln_scan.sh
+++ b/pipeline-assets/image_vuln_scan.sh
@@ -144,7 +144,7 @@ APIKEY=$5
 IGNORE_CONFIG_ISSUES=$6
 IAM_API_URL='https://iam.cloud.ibm.com/identity/token'
 CONTAINER_REGISTRY_URL="https://${REGISTRY_DNS_NAME}/"
-VA_IMAGE_REPORT_API_ENDPOINT='va/api/v3/report/image/'
+VA_IMAGE_REPORT_API_ENDPOINT='va/api/v4/report/image/'
 CONTAINER_REGISTRY="${REGISTRY_DNS_NAME}/${NAMESPACE}"
 CLOUD_VA_REPORT_URL="https://cloud.ibm.com/containers-kubernetes/registry/images/${NAMESPACE}/<image>/<version>/detail/issues?region=ibm:yp:us-south"
 LOCAL_REPORT="/tmp/${IMAGE}-va-report.json"


### PR DESCRIPTION
### Description

migrate to v4 VA image report api

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
