### PR TITLE
Exclude "charts/" folder from check-yaml precommit

### DIFF
--- a/module-assets/.pre-commit-config.yaml
+++ b/module-assets/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
   rev: v4.5.0
   hooks:
     - id: check-yaml
-      exclude: chart/|metadata.yaml|tests/
+      exclude: chart/|charts/|metadata.yaml|tests/
     - id: check-json
       types: [file]
       files: \.(json|releaserc)$


### PR DESCRIPTION
### Description

Adding charts/ path to the ones excluded from check-yaml precommit

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

This change adds `charts/` path to the ones excluded from check-yaml precommit

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
