### PR TITLE
Update install-deps.sh to support intel arch on macOS

### DIFF
--- a/module-assets/ci/install-deps.sh
+++ b/module-assets/ci/install-deps.sh
@@ -332,7 +332,7 @@ if [[ $OSTYPE == 'darwin'* ]]; then
   if [[ "${ARCHITECTURE}" == 'machdep.cpu.brand_string: Intel'* ]]; then
     # macOS on Intel architecture
     TRIVY_ARCH="64bit"
-  else 
+  else
     # macOS on M1 architecture
     TRIVY_ARCH="ARM64"
   fi

--- a/module-assets/ci/install-deps.sh
+++ b/module-assets/ci/install-deps.sh
@@ -328,7 +328,14 @@ TRIVY_OS="Linux"
 TRIVY_ARCH="64bit"
 if [[ $OSTYPE == 'darwin'* ]]; then
   TRIVY_OS="macOS"
-  TRIVY_ARCH="ARM64"
+  ARCHITECTURE="$(sysctl -a | grep machdep.cpu.brand_string)"
+  if [[ "${ARCHITECTURE}" == 'machdep.cpu.brand_string: Intel'* ]]; then
+    # macOS on Intel architecture
+    TRIVY_ARCH="64bit"
+  else 
+    # macOS on M1 architecture
+    TRIVY_ARCH="ARM64"
+  fi
 fi
 
 # renovate: datasource=github-releases depName=aquasecurity/trivy


### PR DESCRIPTION
### Description

Adding support for macOS intel architecture in trivy dependency download in install-deps.sh

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

support for macOS intel architecture in trivy dependency download in install-deps.sh

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
