### PR TITLE
ci: lock into terraform 1.5.7

### DIFF
--- a/module-assets/ci/install-deps.sh
+++ b/module-assets/ci/install-deps.sh
@@ -11,18 +11,21 @@ else
   mkdir -p "${DIRECTORY}"
 fi
 
-# Optionally specify the directory to run tfswitch in. If not speciffied it will run in repo root dir
-if [[ -z "${TFSWITCH_DIRECTORY}" ]]; then
-  TFSWITCH_DIR="."
-else
-  TFSWITCH_DIR="${TFSWITCH_DIRECTORY}"
-fi
-
-# Determine OS type
+# Determine OS type and arch
 if [[ $OSTYPE == 'darwin'* ]]; then
   OS="darwin"
+  # Determine OS arch
+  mac_arch="$(sysctl -a | grep machdep.cpu.brand_string)"
+  if [[ "${mac_arch}" == 'machdep.cpu.brand_string: Intel'* ]]; then
+    # macOS on Intel architecture
+    ARCH="amd64"
+  else
+    # macOS on M1 architecture
+    ARCH="arm64"
+  fi
 else
   OS="linux"
+  ARCH="amd64"
 fi
 
 # Function to download files
@@ -193,7 +196,7 @@ set +e
 INSTALLED_TFSWITCH_VERSION="$(tfswitch --version | grep Version | awk '{ print $2 }')"
 set -e
 if [[ "$TFSWITCH_VERSION" != "$INSTALLED_TFSWITCH_VERSION" ]]; then
-  FILE_NAME="terraform-switcher_${TFSWITCH_VERSION}_${OS}_amd64.tar.gz"
+  FILE_NAME="terraform-switcher_${TFSWITCH_VERSION}_${OS}_${ARCH}.tar.gz"
   URL="https://github.com/warrensbox/terraform-switcher/releases/download/${TFSWITCH_VERSION}"
   SUMFILE="terraform-switcher_${TFSWITCH_VERSION}_checksums.txt"
   TMP_DIR=$(mktemp -d /tmp/${BINARY}-XXXXX)
@@ -224,7 +227,7 @@ set -e
 if [[ "$TERRAFORM_VERSION" != "$INSTALLED_TERRAFORM_VERSION" ]]; then
   # 'v' prefix required for renovate to query github.com for new release, but needs to be removed to pull from hashicorp.com
   TERRAFORM_VERSION="${TERRAFORM_VERSION:1}"
-  FILE_NAME="terraform_${TERRAFORM_VERSION}_${OS}_amd64.zip"
+  FILE_NAME="terraform_${TERRAFORM_VERSION}_${OS}_${ARCH}.zip"
   URL="https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}"
   SUMFILE="terraform_${TERRAFORM_VERSION}_SHA256SUMS"
   TMP_DIR=$(mktemp -d /tmp/${BINARY}-XXXXX)
@@ -242,6 +245,34 @@ else
 fi
 
 #######################################
+# tofu
+#######################################
+
+ # renovate: datasource=github-releases depName=opentofu/opentofu
+TOFU_VERSION=v1.6.2
+BINARY=tofu
+set +e
+INSTALLED_TOFU_VERSION="$(tofu --version | head -1 | cut -d' ' -f2)"
+set -e
+if [[ "$TOFU_VERSION" != "$INSTALLED_TOFU_VERSION" ]]; then
+  FILE_NAME="tofu_${TOFU_VERSION//v}_${OS}_${ARCH}.zip"
+  URL="https://github.com/opentofu/opentofu/releases/download/${TOFU_VERSION}"
+  SUMFILE="tofu_${TOFU_VERSION//v}_SHA256SUMS"
+  TMP_DIR=$(mktemp -d /tmp/${BINARY}-XXXXX)
+
+  echo
+  echo "-- Installing ${BINARY} ${TOFU_VERSION}..."
+
+  download ${BINARY} ${TOFU_VERSION} ${URL} "${FILE_NAME}" "${SUMFILE}" "${TMP_DIR}"
+  verify "${FILE_NAME}" "${SUMFILE}" "${TMP_DIR}"
+  unzip "${TMP_DIR}/${FILE_NAME}" -d "${TMP_DIR}" > /dev/null
+  copy_replace_binary ${BINARY} "${TMP_DIR}"
+  clean "${TMP_DIR}"
+else
+  echo "${BINARY} ${TOFU_VERSION} already installed - skipping install"
+fi
+
+#######################################
 # terraform-docs
 #######################################
 
@@ -252,7 +283,7 @@ set +e
 INSTALLED_TERRADOCS_VERSION="$(terraform-docs --version | head -1 | cut -d' ' -f3)"
 set -e
 if [[ "$TERRAFORM_DOCS_VERSION" != "$INSTALLED_TERRADOCS_VERSION" ]]; then
-  FILE_NAME="terraform-docs-${TERRAFORM_DOCS_VERSION}-${OS}-amd64.tar.gz"
+  FILE_NAME="terraform-docs-${TERRAFORM_DOCS_VERSION}-${OS}-${ARCH}.tar.gz"
   URL="https://github.com/terraform-docs/terraform-docs/releases/download/${TERRAFORM_DOCS_VERSION}"
   SUMFILE="terraform-docs-${TERRAFORM_DOCS_VERSION}.sha256sum"
   TMP_DIR=$(mktemp -d /tmp/${BINARY}-XXXXX)
@@ -279,7 +310,7 @@ set +e
 INSTALLED_TFLINT_VERSION="$(tflint --version | grep "TFLint version " |cut -d' ' -f3)"
 set -e
 if [[ "$TFLINT_VERSION" != "v$INSTALLED_TFLINT_VERSION" ]]; then
-  FILE_NAME="tflint_${OS}_amd64.zip"
+  FILE_NAME="tflint_${OS}_${ARCH}.zip"
   URL="https://github.com/terraform-linters/tflint/releases/download/${TFLINT_VERSION}"
   SUMFILE="checksums.txt"
   TMP_DIR=$(mktemp -d /tmp/${BINARY}-XXXXX)
@@ -304,12 +335,7 @@ TRIVY_OS="Linux"
 TRIVY_ARCH="64bit"
 if [[ $OSTYPE == 'darwin'* ]]; then
   TRIVY_OS="macOS"
-  ARCHITECTURE="$(sysctl -a | grep machdep.cpu.brand_string)"
-  if [[ "${ARCHITECTURE}" == 'machdep.cpu.brand_string: Intel'* ]]; then
-    # macOS on Intel architecture
-    TRIVY_ARCH="64bit"
-  else
-    # macOS on M1 architecture
+  if [[ "${ARCH}" == "arm64" ]]; then
     TRIVY_ARCH="ARM64"
   fi
 fi
@@ -318,10 +344,9 @@ fi
 TRIVY_VERSION=v0.49.1
 BINARY=trivy
 set +e
-INSTALLED_TRIVY_VERSION="$(trivy version)"
-INSTALLED_TRIVY_VERSION_EXTRACTED=("${INSTALLED_TRIVY_VERSION}")
+INSTALLED_TRIVY_VERSION="$(trivy version | grep "Version:" | cut -d' ' -f2)"
 set -e
-if [[ "$TRIVY_VERSION" != "v${INSTALLED_TRIVY_VERSION_EXTRACTED[1]}" ]]; then
+if [[ "$TRIVY_VERSION" != "v${INSTALLED_TRIVY_VERSION}" ]]; then
   FILE_NAME="trivy_${TRIVY_VERSION:1}_${TRIVY_OS}-${TRIVY_ARCH}.tar.gz"
   URL="https://github.com/aquasecurity/trivy/releases/download/${TRIVY_VERSION}"
   SUMFILE="trivy_${TRIVY_VERSION:1}_checksums.txt"
@@ -350,7 +375,7 @@ set +e
 INSTALLED_GOLANGCI_LINT_VERSION="$(golangci-lint --version | head -1 | cut -d' ' -f4)"
 set -e
 if [[ "$GOLANGCI_LINT_VERSION" != "v$INSTALLED_GOLANGCI_LINT_VERSION" ]]; then
-  FILE_NAME="golangci-lint-${GOLANGCI_LINT_VERSION//v/}-${OS}-amd64.tar.gz"
+  FILE_NAME="golangci-lint-${GOLANGCI_LINT_VERSION//v/}-${OS}-${ARCH}.tar.gz"
   URL="https://github.com/golangci/golangci-lint/releases/download/${GOLANGCI_LINT_VERSION}"
   SUMFILE="${BINARY}-${GOLANGCI_LINT_VERSION//v/}-checksums.txt"
   TMP_DIR=$(mktemp -d /tmp/${BINARY}-XXXXX)
@@ -361,7 +386,7 @@ if [[ "$GOLANGCI_LINT_VERSION" != "v$INSTALLED_GOLANGCI_LINT_VERSION" ]]; then
   download ${BINARY} ${GOLANGCI_LINT_VERSION} ${URL} "${FILE_NAME}" "${SUMFILE}" "${TMP_DIR}"
   verify "${FILE_NAME}" "${SUMFILE}" "${TMP_DIR}"
   tar -xzf "${TMP_DIR}/${FILE_NAME}" -C "${TMP_DIR}"
-  copy_replace_binary ${BINARY} "${TMP_DIR}/golangci-lint-${GOLANGCI_LINT_VERSION//v/}-${OS}-amd64"
+  copy_replace_binary ${BINARY} "${TMP_DIR}/golangci-lint-${GOLANGCI_LINT_VERSION//v/}-${OS}-${ARCH}"
   clean "${TMP_DIR}"
 else
   echo "${BINARY} ${GOLANGCI_LINT_VERSION} already installed - skipping install"
@@ -433,9 +458,9 @@ set +e
 INSTALLED_HELM_VERSION="$(helm version | cut -d':' -f2 | cut -d'"' -f2)"
 set -e
 if [[ "$HELM_VERSION" != "$INSTALLED_HELM_VERSION" ]]; then
-  FILE_NAME="helm-${HELM_VERSION}-${OS}-amd64.tar.gz"
+  FILE_NAME="helm-${HELM_VERSION}-${OS}-${ARCH}.tar.gz"
   URL="https://get.helm.sh"
-  SUMFILE="helm-${HELM_VERSION}-${OS}-amd64.tar.gz.sha256"
+  SUMFILE="helm-${HELM_VERSION}-${OS}-${ARCH}.tar.gz.sha256"
   TMP_DIR=$(mktemp -d /tmp/${BINARY}-XXXXX)
 
   echo
@@ -444,7 +469,7 @@ if [[ "$HELM_VERSION" != "$INSTALLED_HELM_VERSION" ]]; then
   download ${BINARY} ${HELM_VERSION} ${URL} ${FILE_NAME} "${SUMFILE}" "${TMP_DIR}"
   verify_alternative ${FILE_NAME} ${SUMFILE} "${TMP_DIR}"
   tar -xzf "${TMP_DIR}/${FILE_NAME}" -C "${TMP_DIR}"
-  copy_replace_binary ${BINARY} "${TMP_DIR}/${OS}-amd64"
+  copy_replace_binary ${BINARY} "${TMP_DIR}/${OS}-${ARCH}"
   clean "${TMP_DIR}"
 else
   echo "${BINARY} ${HELM_VERSION} already installed - skipping install"
@@ -461,7 +486,7 @@ INSTALLED_KUBECTL_VERSION="$(kubectl version --output yaml --client | grep "gitV
 set -e
 if [[ "$KUBECTL_VERSION" != "$INSTALLED_KUBECTL_VERSION" ]]; then
   FILE_NAME="kubectl"
-  URL="https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/${OS}/amd64"
+  URL="https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/${OS}/${ARCH}"
   SUMFILE="kubectl.sha256"
   TMP_DIR=$(mktemp -d /tmp/${BINARY}-XXXXX)
 
@@ -493,7 +518,7 @@ INSTALLED_OC_VERSION="$(oc version --client | grep "Client Version:" | cut -d' '
 set -e
 if [[ "$OC_VERSION" != "$INSTALLED_OC_VERSION" ]]; then
   FILE_NAME="openshift-client-${OC_OS}-${OC_VERSION}.tar.gz"
-  URL="https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/${OC_VERSION}"
+  URL="https://mirror.openshift.com/pub/openshift-v4/${ARCH}/clients/ocp/${OC_VERSION}"
   SUMFILE="sha256sum.txt"
   TMP_DIR=$(mktemp -d /tmp/${BINARY}-XXXXX)
 
@@ -515,18 +540,18 @@ fi
 
 JQ_OS=${OS}
 if [[ $OSTYPE == 'darwin'* ]]; then
-  JQ_OS="osx-amd"
+  JQ_OS="macos"
 fi
 
- # renovate: datasource=github-releases depName=stedolan/jq
-JQ_VERSION=1.6
+ # renovate: datasource=github-releases depName=jqlang/jq
+JQ_VERSION=1.7.1
 BINARY=jq
 set +e
 INSTALLED_JQ_VERSION="$(jq --version | cut -c4-)"
 set -e
 if [[ "$JQ_VERSION" != "$INSTALLED_JQ_VERSION" ]]; then
-  FILE_NAME="jq-${JQ_OS}64"
-  URL="https://github.com/stedolan/jq/releases/download/jq-${JQ_VERSION}"
+  FILE_NAME="jq-${JQ_OS}-${ARCH}"
+  URL="https://github.com/jqlang/jq/releases/download/jq-${JQ_VERSION}"
   SUMFILE=""
   TMP_DIR=$(mktemp -d /tmp/${BINARY}-XXXXX)
 


### PR DESCRIPTION
### Description

We are going to temporarily lock our CI environment into using terraform 1.5.7 while we update the version constraints of all our modules to allow terraform 1.6. It means we won't hit any circular dependency issues since CI runtime will still use 1.5.7. 
Once we have updated all modules, we will switch our tests to start using opentofu.

I'm also removing terragrunt, as we no longer need it, and also adding opentofu.

Removed tfswitch too, and updated the downloads to use `amd` or `arm` depending on what it detects in the runtime OS.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [x] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
