### PR TITLE
increase golang test timeout

### DIFF
--- a/module-assets/Makefile
+++ b/module-assets/Makefile
@@ -127,7 +127,7 @@ run-tests: ghe-netrc
 
 # run tests for terraform repos locally
 run-tests-local:
-	cd ${GO_TEST_DIR} && go test -run ${RUN} -count=1 -v -timeout 300m
+	cd ${GO_TEST_DIR} && go test -run ${RUN} -count=1 -v -timeout 600m
 
 # run unit tests for golang projects
 run-go-module-tests:

--- a/module-assets/ci/run-tests.sh
+++ b/module-assets/ci/run-tests.sh
@@ -133,7 +133,7 @@ if [ ${IS_PR} == true ]; then
     if test -f "${pr_test_file}"; then
         test_arg=${pr_test_file}
     fi
-    test_cmd="go test ${test_arg} -count=1 -v -timeout=300m -parallel=10"
+    test_cmd="go test ${test_arg} -count=1 -v -timeout=600m -parallel=10"
     if [[ "$MZ_INGESTION_KEY" ]] ; then
       # Assign location to be observed by logdna-agent
       if [ -z "$MZ_LOG_DIRS" ]; then


### PR DESCRIPTION
### Description

increase golang test timeout to 10 hours for MAS DA tests

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
