### PR TITLE
fix: updated to not run tests on empty commit

### DIFF
--- a/module-assets/ci/run-tests.sh
+++ b/module-assets/ci/run-tests.sh
@@ -106,23 +106,23 @@ if [ ${IS_PR} == true ]; then
   if [ "${file_array[*]}" == "" ]; then
     echo "No files found in file array"
     match=true
-  fi
-
-  # Check if any file in skip_array matches any of the files being updated in the PR
-  for f in "${file_array[@]}"; do
-    match=false
-    for s in "${skip_array[@]}"; do
-      if [[ "$f" =~ $s ]]; then
-        # File has matched one in the skip_array - break out of loop to try next file
-        match=true
+  else
+    # Check if any file in skip_array matches any of the files being updated in the PR
+    for f in "${file_array[@]}"; do
+      match=false
+      for s in "${skip_array[@]}"; do
+        if [[ "$f" =~ $s ]]; then
+          # File has matched one in the skip_array - break out of loop to try next file
+          match=true
+          break
+        fi
+      done
+      if [ "${match}" == "false" ]; then
+        # No need to iterate through any more files as PR contains a file not in skip_array
         break
       fi
     done
-    if [ "${match}" == "false" ]; then
-      # No need to iterate through any more files as PR contains a file not in skip_array
-      break
-    fi
-  done
+  fi
 
   # If there are any files being updated in the PR that are not in the skip list, then run the tests
   if [ "${match}" == "false" ]; then


### PR DESCRIPTION
### Description

The array to check the skip files has been moved to an else block after checking the length of it. This should fix the problem as we may be running into the same problem as the comment states that $file_array[@] will return 1 even if it is empty so it would be running the loop at least once, switching match to false.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
