### PR TITLE
feat: updated skip array based on repo name

### DIFF
--- a/module-assets/ci/run-tests.sh
+++ b/module-assets/ci/run-tests.sh
@@ -98,9 +98,10 @@ if [ ${IS_PR} == true ]; then
 
   # Remove `ibm_catalog.json` only if the repo name starts with `stack-`
   if [[ $REPO_NAME == "stack-*" ]]; then
-    for f in "${!skip_array[@]}"; do
-      if [[ "${skip_array[$f]}" == "ibm_catalog.json" ]]; then
-        unset "skip_array[$f]"
+    for index in "${!skip_array[@]}"; do
+      if [[ "${skip_array[$index]}" == "ibm_catalog.json" ]]; then
+        unset "skip_array[$index]"
+        break
       fi
     done
     # reindex the array
@@ -119,10 +120,10 @@ if [ ${IS_PR} == true ]; then
     match=true
   else
     # Check if any file in skip_array matches any of the files being updated in the PR
-    for f in "${file_array[@]}"; do
+    for index in "${file_array[@]}"; do
       match=false
       for s in "${skip_array[@]}"; do
-        if [[ "$f" =~ $s ]]; then
+        if [[ "$index" =~ $s ]]; then
           # File has matched one in the skip_array - break out of loop to try next file
           match=true
           break
@@ -141,7 +142,7 @@ if [ ${IS_PR} == true ]; then
     test_arg=""
     # If pr_test.go exists, only execute those tests
     pr_test_file=pr_test.go
-    if test -f "${pr_test_file}"; then
+    if test -index "${pr_test_file}"; then
         test_arg=${pr_test_file}
     fi
     test_cmd="go test ${test_arg} -count=1 -v -timeout=600m -parallel=10"

--- a/module-assets/ci/run-tests.sh
+++ b/module-assets/ci/run-tests.sh
@@ -96,6 +96,17 @@ if [ ${IS_PR} == true ]; then
                          ".catalog-onboard-pipeline.yaml"
                          ".trivyignore")
 
+  # Remove `ibm_catalog.json` only if the repo name starts with `stack-`
+  if [[ $REPO_NAME == "stack-*" ]]; then
+    for f in "${!skip_array[@]}"; do
+      if [[ "${skip_array[$f]}" == "ibm_catalog.json" ]]; then
+        unset "skip_array[$f]"
+      fi
+    done
+    # reindex the array
+    skip_array=("${skip_array[@]}")
+  fi
+
   # Determine all files being changed in the PR, and add it to array
   changed_files="$(git diff --name-only "${TARGET_BRANCH}..HEAD" --)"
   mapfile -t file_array <<< "${changed_files}"


### PR DESCRIPTION
### Description

This PR addresses the change to modify the array only if the repo name starts with `stack-`
Refer [Issue-9655](https://github.ibm.com/GoldenEye/issues/issues/9655)

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [x] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
