### PR TITLE
feat: expose persistent MQ capacity instance CRN

### DIFF
--- a/common-go-assets/common-permanent-resources.yaml
+++ b/common-go-assets/common-permanent-resources.yaml
@@ -121,7 +121,7 @@ kp_us_south_root_key_crn: "crn:v1:bluemix:public:kms:us-south:a/9f9af00a96104f49
 kp_us_south_root_key_id: "f6c9f6d0-92f6-437a-b97c-4b617cb3d320"
 
 # IBM MQ on Cloud capacity instance (geretain-mqoc)
-# CRN: crn:v1:bluemix:public:mqcloud:us-east:a/abac0df06b644a9cabc6e44f55b3880e:9d9a3c00-2097-4da4-a5e4-78e06514b342::
+mq_capacity_crn: "crn:v1:bluemix:public:mqcloud:us-east:a/abac0df06b644a9cabc6e44f55b3880e:9d9a3c00-2097-4da4-a5e4-78e06514b342::"
 mq_capacity_guid: "9d9a3c00-2097-4da4-a5e4-78e06514b342"
 
 # IBM MQ Queue Manager license and usage. More info: https://www.ibm.com/docs/en/ibm-mq/9.3?topic=mqibmcomv1beta1-licensing-reference


### PR DESCRIPTION
### Description

Expose the persistent MQ capacity service instance CRN for consumption by the DA.

CRNs contain more information and are a more comfortable resource to work with in DAs.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [x] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

Expose the persistent MQ capacity service instance CRN

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
