### PR TITLE
ci: remove us regions from SM tests

### DIFF
--- a/common-go-assets/cloudinfo-region-secmgr-prefs.yaml
+++ b/common-go-assets/cloudinfo-region-secmgr-prefs.yaml
@@ -8,12 +8,6 @@
 - name: ca-tor
   useForTest: true
   testPriority: 3
-- name: jp-osa
-  useForTest: true
-  testPriority: 9
-- name: jp-tok
-  useForTest: true
-  testPriority: 10
 - name: eu-de
   useForTest: true
   testPriority: 4
@@ -24,8 +18,14 @@
   useForTest: true
   testPriority: 6
 - name: us-east
-  useForTest: true
+  useForTest: false # we have been asked to not use us regions for test: https://ibm-cloudplatform.slack.com/archives/C010Z1DQ05N/p1724936766805639
   testPriority: 7
 - name: us-south
-  useForTest: true
+  useForTest: false # we have been asked to not use us regions for test: https://ibm-cloudplatform.slack.com/archives/C010Z1DQ05N/p1724936766805639
   testPriority: 8
+- name: jp-osa
+  useForTest: true
+  testPriority: 9
+- name: jp-tok
+  useForTest: true
+  testPriority: 10

--- a/common-go-assets/cloudinfo-region-secmgr-prefs.yaml
+++ b/common-go-assets/cloudinfo-region-secmgr-prefs.yaml
@@ -1,11 +1,11 @@
 ---
-- name: au-syd
-  useForTest: true
-  testPriority: 1
 - name: br-sao
   useForTest: true
-  testPriority: 2
+  testPriority: 1
 - name: ca-tor
+  useForTest: true
+  testPriority: 2
+- name: au-syd
   useForTest: true
   testPriority: 3
 - name: eu-de


### PR DESCRIPTION
### Description

Remove us-south and us-east from secrets manager test region selector per announcement from Secrets Manager team.

Announcement: https://ibm-cloudplatform.slack.com/archives/C010Z1DQ05N/p1724936766805639

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
