### PR TITLE
skip checkov github_configuration checks

### DIFF
--- a/module-assets/.pre-commit-config.yaml
+++ b/module-assets/.pre-commit-config.yaml
@@ -85,6 +85,7 @@ repos:
         - --skip-path=Dockerfile
         - --skip-path=ibm_catalog.json
         - --skip-framework=github_actions
+        - --skip-framework=github_configuration
         - --skip-path=modules/logs-routing-module
         - --skip-path=helm-charts
         # see https://github.ibm.com/GoldenEye/issues/issues/5317


### PR DESCRIPTION
### Description

We do not want checkov to verify `github_configuration` checks. Checks such as the below are being seen in some pipelines:

```

Check: CKV_GITHUB_26: "Ensure minimum admins are set for the organization"
	FAILED for resource: /github_conf/org_admins.json.*./github_conf/org_admins.json.CKV_GITHUB_26
	File: /org_admins.json:1-221
```
### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [x] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
