### PR TITLE
PR should run infrastructure tests when common-dev-assets is being updated

### DIFF
--- a/module-assets/ci/run-tests.sh
+++ b/module-assets/ci/run-tests.sh
@@ -62,7 +62,7 @@ fi
 if [ ${IS_PR} == true ]; then
 
   # Files that should not trigger tests
-  # NOTE: We are purposely running tests in PRs with 'common-dev-assets' GIT submodule updates since 
+  # NOTE: We are purposely running tests in PRs with 'common-dev-assets' GIT submodule updates since
   # terraform version can change, and we will want to run full set of tests if that happens)
   declare -a skip_array=(".drawio"
                          ".github/settings.yml"

--- a/module-assets/ci/run-tests.sh
+++ b/module-assets/ci/run-tests.sh
@@ -63,7 +63,7 @@ if [ ${IS_PR} == true ]; then
 
   # Files that should not trigger tests
   # NOTE: We are purposely running tests in PRs with 'common-dev-assets' GIT submodule updates since
-  # terraform version can change, and we will want to run full set of tests if that happens)
+  # terraform version can change, and we will want to run full set of tests if that happens.
   declare -a skip_array=(".drawio"
                          ".github/settings.yml"
                          ".github/workflows/ci.yml"

--- a/module-assets/ci/run-tests.sh
+++ b/module-assets/ci/run-tests.sh
@@ -62,6 +62,8 @@ fi
 if [ ${IS_PR} == true ]; then
 
   # Files that should not trigger tests
+  # NOTE: We are purposely running tests in PRs with 'common-dev-assets' GIT submodule updates since 
+  # terraform version can change, and we will want to run full set of tests if that happens)
   declare -a skip_array=(".drawio"
                          ".github/settings.yml"
                          ".github/workflows/ci.yml"
@@ -80,7 +82,6 @@ if [ ${IS_PR} == true ]; then
                          "Brewfile"
                          "CODEOWNERS"
                          "commitlint.config.js"
-                         "common-dev-assets"
                          "Makefile"
                          "renovate.json"
                          "catalogValidationValues.json.template"


### PR DESCRIPTION
### Description

We want to purposely run tests in PRs with 'common-dev-assets' GIT submodule updates since terraform version can change, and we will want to run full set of tests if that happens.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
