### PR TITLE
feat : Detect ibm_catalog.json

### DIFF
--- a/module-assets/ci/license_checker.sh
+++ b/module-assets/ci/license_checker.sh
@@ -7,11 +7,15 @@ if git remote -v | head -n 1 | grep -q "github.ibm"; then
   exit 0
 fi
 
+
 # ensure LICENSE file exists if .tf file is detected in root directory
-count=$(find ./*.tf 2>/dev/null | wc -l | xargs)
+
+count=$(find ./ -type f \( -name *.tf -o -name ibm_catalog.json \) 2>/dev/null | wc -l | xargs)
 if [ "$count" != 0 ]; then
   if [[ ! -f "LICENSE" ]]; then
     echo "Required LICENSE file is missing. Please add it and try again."
     exit 1
   fi
 fi
+
+  

--- a/module-assets/ci/license_checker.sh
+++ b/module-assets/ci/license_checker.sh
@@ -8,14 +8,12 @@ if git remote -v | head -n 1 | grep -q "github.ibm"; then
 fi
 
 
-# ensure LICENSE file exists if .tf file is detected in root directory
+# ensure LICENSE file exists if .tf file is detected incd root directory
 
-count=$(find ./ -type f \( -name *.tf -o -name ibm_catalog.json \) 2>/dev/null | wc -l | xargs)
+count=$(find . -maxdepth 1 \( -name "*.tf" -o -name "ibm_catalog.json" \) 2>/dev/null | wc -l | xargs)
 if [ "$count" != 0 ]; then
   if [[ ! -f "LICENSE" ]]; then
     echo "Required LICENSE file is missing. Please add it and try again."
     exit 1
   fi
 fi
-
-  


### PR DESCRIPTION
### Description

This PR enhances the existing shell script by adding functionality to detect ibm_catalog.json files in a specified directory.After the changes the hook will run if ibm_catalog.json or .tf file is in the repo and if it exist it should mandate LICENSE file.
Issue:https://github.ibm.com/GoldenEye/issues/issues/8715


### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`0.1.0`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
