### PR TITLE
Removed `DOCKER_ENV` from Makefile - it is no longer used

### DIFF
--- a/module-assets/Makefile
+++ b/module-assets/Makefile
@@ -31,10 +31,6 @@ ifneq (,$(filter $(detected_OS), Darwin Linux))
 	.DEFAULT_GOAL = all
 endif
 
-ifndef DOCKER_ENV
-	DOCKER_ENV := common-dev-assets/module-assets/docker.env
-endif
-
 ifndef GO_TEST_DIR
 	GO_TEST_DIR := tests
 endif

--- a/module-assets/docker.env
+++ b/module-assets/docker.env
@@ -1,6 +1,0 @@
-# File to add environment variables required by terraform providers.
-# Environment variables in this file will be available in goldeneye-ci-image during execution of tests
-
-# This environment variable is used by terraform-provider-restapi provider to hide sensitive data
-# during the execution of all terraform operations (plan, apply, destroy) and their respective outputs
-API_DATA_IS_SENSITIVE=true


### PR DESCRIPTION
### Description

Removed `DOCKER_ENV` from Makefile - it is no longer used. It used to be used as part of an old Make command when running tests, but this command was updated a long time ago and hence is no longer used.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
