### PR TITLE
fix: rollback antonbabenko/pre-commit-terraform to 1.96.3 for trivy h…

### DIFF
--- a/module-assets/.pre-commit-config.yaml
+++ b/module-assets/.pre-commit-config.yaml
@@ -40,8 +40,8 @@ repos:
   hooks:
     - id: hadolint
 - repo: https://github.com/antonbabenko/pre-commit-terraform
-  # locking to v1.97.3 to avoid issue tracked at https://github.com/antonbabenko/pre-commit-terraform/issues/833
-  rev: v1.97.3
+  # locking to v1.96.3 to avoid issue tracked at https://github.com/antonbabenko/pre-commit-terraform/issues/833
+  rev: v1.96.3
   hooks:
     - id: terraform_fmt
     - id: terraform_validate

--- a/module-assets/.pre-commit-config.yaml
+++ b/module-assets/.pre-commit-config.yaml
@@ -40,7 +40,8 @@ repos:
   hooks:
     - id: hadolint
 - repo: https://github.com/antonbabenko/pre-commit-terraform
-  rev: v1.97.4
+  # locking to v1.97.3 to avoid issue tracked at https://github.com/antonbabenko/pre-commit-terraform/issues/833
+  rev: v1.97.3
   hooks:
     - id: terraform_fmt
     - id: terraform_validate

--- a/renovate.json
+++ b/renovate.json
@@ -16,5 +16,12 @@
       "matchStrings": ["\\s+image: (?<depName>.*?)(?::(?<currentValue>.*?))?@(?<currentDigest>sha256:[a-f0-9]+)\\s"],
       "datasourceTemplate": "docker"
     }
+  ],
+  "packageRules": [
+    {
+      "description": "locking to v1.97.3 while waiting for https://github.com/antonbabenko/pre-commit-terraform/issues/833 to be fixed",
+      "matchPackageNames": ["antonbabenko/pre-commit-terraform"],
+      "enabled": false
+    }
   ]
 }


### PR DESCRIPTION
### Description

rollback antonbabenko/pre-commit-terraform to 1.96.3 for trivy hook error

hook issue tracked https://github.com/antonbabenko/pre-commit-terraform/issues/833

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [x] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

rollback antonbabenko/pre-commit-terraform to 1.96.3 for trivy hook error

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
