### PR TITLE
fix: add image name to rhelai image url

### DIFF
--- a/common-go-assets/common-permanent-resources.yaml
+++ b/common-go-assets/common-permanent-resources.yaml
@@ -178,7 +178,7 @@ general_test_storage_cos_instance_resource_group: "geretain-test-permanent"
 # RHEL-AI project test resources
 rhelai_image_cos_bucket_crn: "crn:v1:bluemix:public:cloud-object-storage:global:a/abac0df06b644a9cabc6e44f55b3880e:855ed836-05ce-4f39-98fa-508774f29323:bucket:geretain-rhelai-test-images"
 rhelai_image_cos_bucket_name: "geretain-rhelai-test-images"
-rhelai_image_cos_bucket_url: "cos://us-south/geretain-rhelai-test-images"
+rhelai_image_cos_bucket_url: "cos://us-south/geretain-rhelai-test-images/rhel-ai-nvidia-1.4-1739107849-x86_64-kvm.qcow2"
 rhelai_image_cos_bucket_region: "us-south"
 
 rhelai_model_cos_bucket_crn: "crn:v1:bluemix:public:cloud-object-storage:global:a/abac0df06b644a9cabc6e44f55b3880e:855ed836-05ce-4f39-98fa-508774f29323:bucket:geretain-rhelai-test-models"


### PR DESCRIPTION
### Description

Added the current rhel-ai image name to the end of the bucket url, in order to create a complete web URL pointing to the file itself.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
