### PR TITLE
fix: updated perm snapshot values after refresh

### DIFF
--- a/common-go-assets/common-permanent-resources.yaml
+++ b/common-go-assets/common-permanent-resources.yaml
@@ -146,10 +146,10 @@ account_level_tenant_id: "35daa2ef-759b-4189-8596-e7a0907e8582"
 account_level_tenant_crn: "crn:v1:bluemix:public:logs-router:us-east:a/abac0df06b644a9cabc6e44f55b3880e:35daa2ef-759b-4189-8596-e7a0907e8582::"
 
 # VSI Snapshot Consistency Group
-snapshot_group_au_syd_group_id: "r026-43d41ad0-88f4-4e99-8adf-0cae4a02710c"
-snapshot_group_au_syd_boot_id: "r026-88f05225-d0aa-4d4e-896f-0135ae569bcc"
-snapshot_group_au_syd_vol1_id: "r026-daf63a97-c445-4f9c-bb54-d6e371e95388"
-snapshot_group_au_syd_vol2_id: "r026-1518ae7d-319c-4164-a781-56067e9be451"
+snapshot_group_au_syd_group_id: "r026-3fa43751-8250-4de0-aac3-b45c7145b178"
+snapshot_group_au_syd_boot_id: "r026-1fc0436f-eb3b-47a5-8ace-79414494d645"
+snapshot_group_au_syd_vol1_id: "r026-94dffa4c-9f78-4710-9364-ba8c7e0f3ff2"
+snapshot_group_au_syd_vol2_id: "r026-81e47123-c33a-4e48-9d3d-0dc05a84046a"
 
 # etcd instance crn for backup-restore test
 etcd_crn: "crn:v1:bluemix:public:databases-for-etcd:us-south:a/abac0df06b644a9cabc6e44f55b3880e:0acee023-4933-4e3b-a7ed-118e2c79fcca::"


### PR DESCRIPTION
### Description

Needed to recreate the permanent VSI snapshots, this PR will update the new IDs for those backups.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
