### PR TITLE
fix: changed IDs for rabbitmq and ce public cert

### DIFF
--- a/common-go-assets/common-permanent-resources.yaml
+++ b/common-go-assets/common-permanent-resources.yaml
@@ -30,7 +30,7 @@ dnsDelegatedCloudDomain: "goldeneye.appdomain.cloud" # https://github.ibm.com/Co
 dnsDelegatedIBMDomain: "goldeneye.dev.cloud.ibm.com" # https://github.ibm.com/CoreCloud/cloud.ibm.com/issues/1244
 
 # code engine public cert
-cePublicCertId: "78892bbb-ca34-2a1d-3f97-f3018348581a"
+cePublicCertId: "01262dac-7fcf-c40e-794d-7b8d7b67b772"
 cePublicCertCommonName: "geretain-code-engine-public-cert"
 
 # IAM ServiceID for Service dnlb
@@ -92,8 +92,8 @@ elasticsearchVersion: 8.15
 elasticsearchRegion: "us-south"
 
 # rabbitMQ instance crn for backup-restore test
-rabbitmqCrn: "crn:v1:bluemix:public:messages-for-rabbitmq:us-south:a/abac0df06b644a9cabc6e44f55b3880e:6b86d46e-8f2f-4508-82fb-3f1597f4035b::"
-rabbitmqVersion: 3.12
+rabbitmqCrn: "crn:v1:bluemix:public:messages-for-rabbitmq:us-south:a/abac0df06b644a9cabc6e44f55b3880e:956e6e71-2655-49a1-a367-abf009cf1901::"
+rabbitmqVersion: 3.13
 rabbitmqRegion: "us-south"
 
 # redis instance crn for backup-restore test


### PR DESCRIPTION
### Description

changed ID for rabbitmq as previous been deprecated
changed ID for code engince public certificate been recreated as its secret group was regenerated due to IAM credentials deletion in SM

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [x] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
