### PR TITLE
Remove incorrect report URL from image_vuln_scan.sh

### DIFF
--- a/pipeline-assets/image_vuln_scan.sh
+++ b/pipeline-assets/image_vuln_scan.sh
@@ -74,8 +74,6 @@ check_vulnerability_scan() {
     TOKEN=$3
     IGNORE_CONFIG=$4
     SCAN_ENGINES=$5
-    CLOUD_VA_REPORT_URL=${CLOUD_VA_REPORT_URL/<image>/$IMAGE}
-    CLOUD_VA_REPORT_URL=${CLOUD_VA_REPORT_URL/<version>/$VERSION}
     local response
     local status
     response=$(curl -Lks -H "Authorization: $TOKEN" -H "Scan-Engines: ${SCAN_ENGINES}" "${CONTAINER_REGISTRY_URL}${VA_IMAGE_REPORT_API_ENDPOINT}${CONTAINER_REGISTRY}/${IMAGE}:${VERSION}")
@@ -125,8 +123,6 @@ check_vulnerability_scan() {
               echo "PASS" > "${RESULT_FILE}"
           fi
         fi
-
-        echo "IBM CLOUD REPORT: ${CLOUD_VA_REPORT_URL}"
         return 0
     fi
 }
@@ -157,7 +153,6 @@ IAM_API_URL='https://iam.cloud.ibm.com/identity/token'
 CONTAINER_REGISTRY_URL="https://${REGISTRY_DNS_NAME}/"
 VA_IMAGE_REPORT_API_ENDPOINT='va/api/v4/report/image/'
 CONTAINER_REGISTRY="${REGISTRY_DNS_NAME}/${NAMESPACE}"
-CLOUD_VA_REPORT_URL="https://cloud.ibm.com/containers-kubernetes/registry/images/${NAMESPACE}/<image>/<version>/detail/issues?region=ibm:yp:us-south"
 LOCAL_REPORT="/tmp/${IMAGE}-va-report.json"
 token=$(get_bearer_token "$APIKEY")
 TMP_DIR=$(mktemp -d /tmp/ci-XXXXXXXXXX)


### PR DESCRIPTION
### Description

Remove incorrect report URL from image_vuln_scan.sh. 
The new URL requires the SHA and some other details to be base64 encoded so not straugth forward to replace. Will revisit in the future perhaps, but for now removing the invalid URL that is printed in logs.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
