### PR TITLE
Revert "Update commonRenovateConfig.json"

### DIFF
--- a/commonRenovateConfig.json
+++ b/commonRenovateConfig.json
@@ -50,7 +50,6 @@
     {
       "description": "Bundle terraform related updates into the same PR and priortise creation of these PRs.",
       "matchManagers": ["terraform", "terraform-version"],
-      "matchDatasources": ["terraform-module", "terraform-provider"],
       "groupName": "Terraform dependencies",
       "prPriority": 10
     },


### PR DESCRIPTION
Reverts terraform-ibm-modules/common-dev-assets#1195

It seemed to cause an issue which omitted internal module updates grouping in same PRs