### PR TITLE
fix(deps): bump persistent mongodb version

### DIFF
--- a/common-go-assets/common-permanent-resources.yaml
+++ b/common-go-assets/common-permanent-resources.yaml
@@ -78,7 +78,7 @@ mysqlPITRRegion: "us-south"
 
 # mongoDB instance crn for backup-restore test
 mongodbCrn: "crn:v1:bluemix:public:databases-for-mongodb:us-south:a/abac0df06b644a9cabc6e44f55b3880e:10e1efff-d5fa-4d83-adef-f47f81ac5f00::"
-mongodbVersion: 6
+mongodbVersion: 7.0
 mongodbRegion: "us-south"
 
 # ElasticSearch instance crn for backup-restore test


### PR DESCRIPTION
### Description

The persistent mongo db instance in GE dev account was updated in place. It retains the same CRN and the new version is 7.0.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
