### PR TITLE
Update postUpgradeTasks commands in Renovate config

### DIFF
--- a/commonRenovateConfig.json
+++ b/commonRenovateConfig.json
@@ -25,7 +25,7 @@
   ],
   "postUpdateOptions": ["gomodTidy", "gomodUpdateImportPaths"],
   "postUpgradeTasks": {
-    "commands": ["git submodule update --remote --merge && export CUSTOM_DIRECTORY=/tmp && export PATH=$PATH:/tmp && make dependency-install-darwin-linux && cp /opt/containerbase/tools/golang/*/bin/gofmt /tmp", "export PATH=$PATH:/tmp && pre-commit run --all-files || true"],
+    "commands": ["git submodule update --remote --merge && export CUSTOM_DIRECTORY=/tmp && export PIPX_GLOBAL_HOME=/tmp && export PATH=$PATH:/tmp && make dependency-install-darwin-linux && cp /opt/containerbase/tools/golang/*/bin/gofmt /tmp", "export PATH=$PATH:/tmp && pre-commit run --all-files || true"],
     "fileFilters": ["**/*.md", "**/*.py", "**/*.toml", "**/*.json", ".secrets.baseline", "**/*.tf", "**/*.go", "go.mod", "go.sum", "common-dev-assets", "armada-csutil", "modules/logs-routing-module/helm-charts", "modules/prometheus-module/helm-charts"],
     "executionMode": "branch"
   },


### PR DESCRIPTION
### Description

Had to add `export PIPX_GLOBAL_HOME=/tmp` because the default direvtory `/opt/pipx` does not have write permissions in the renovate image:
```
$ python3 -m pipx ensurepath --global
Traceback (most recent call last):
  File "/opt/containerbase/tools/python/3.13.7/lib/python3.13/pathlib/_local.py", line 722, in mkdir
    os.mkdir(self, mode)
    ~~~~~~~~^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: '/opt/pipx/venvs'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/home/ubuntu/.local/lib/python3.13/site-packages/pipx/__main__.py", line 14, in <module>
    sys.exit(cli())
             ~~~^^
  File "/home/ubuntu/.local/lib/python3.13/site-packages/pipx/main.py", line 1171, in cli
    setup(parsed_pipx_args)
    ~~~~~^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/.local/lib/python3.13/site-packages/pipx/main.py", line 1113, in setup
    mkdir(paths.ctx.venvs)
    ~~~~~^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/.local/lib/python3.13/site-packages/pipx/util.py", line 77, in mkdir
    path.mkdir(parents=True, exist_ok=True)
    ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/containerbase/tools/python/3.13.7/lib/python3.13/pathlib/_local.py", line 726, in mkdir
    self.parent.mkdir(parents=True, exist_ok=True)
    ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/containerbase/tools/python/3.13.7/lib/python3.13/pathlib/_local.py", line 722, in mkdir
    os.mkdir(self, mode)
    ~~~~~~~~^^^^^^^^^^^^
PermissionError: [Errno 13] Permission denied: '/opt/pipx'
```

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [x] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
