### PR TITLE
Update jq version from 1.7.1 to 1.8.1

### DIFF
--- a/module-assets/ci/install-deps.sh
+++ b/module-assets/ci/install-deps.sh
@@ -735,7 +735,7 @@ if [[ $OSTYPE == 'darwin'* ]]; then
 fi
 
  # renovate: datasource=github-releases depName=jqlang/jq
-JQ_VERSION=1.7.1
+JQ_VERSION=1.8.1
 BINARY=jq
 set +e
 INSTALLED_JQ_VERSION="$(jq --version | cut -c4-)"


### PR DESCRIPTION
### Description

Manually updating jq to the current latest (the renovate rule is broken and needs to be updated to manage this version - we are already internally tracking this)

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [x] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
