### PR TITLE
fix: add fix for stack repos in validateIbmCatalogJson.py

### DIFF
--- a/module-assets/ci/validateIbmCatalogJson.py
+++ b/module-assets/ci/validateIbmCatalogJson.py
@@ -188,7 +188,6 @@ def check_ibm_catalog_file():
 
                     # - repo does not have 'stack-' in the name
                     if "stack-" not in repo_name:
-
                         # compare input variables defined in a solution with the one's defined in ibm_catalog.json
                         inputs_not_in_catalog = check_inputs_missing(
                             da_inputs_names, catalog_inputs_names


### PR DESCRIPTION
### Description

The changes in https://github.com/terraform-ibm-modules/common-dev-assets/pull/1257 caused a regression for stack repos. Fix is in the PR

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
