### PR TITLE
Add regex manager for bash library versioning

### DIFF
--- a/commonRenovateConfig.json
+++ b/commonRenovateConfig.json
@@ -34,6 +34,18 @@
     "fileFilters": ["**/*.md", "**/*.py", "**/*.toml", "**/*.json", ".secrets.baseline", "**/*.tf", "**/*.go", "go.mod", "go.sum", "common-dev-assets", "armada-csutil", "modules/supertenant-logs-routing-and-icl-agent/helm-charts", "modules/supertenant-logs-routing-agent/helm-charts", "modules/atracker-agent/helm-charts", "modules/logs-routing-module/helm-charts", "modules/prometheus-module/helm-charts"],
     "executionMode": "branch"
   },
+  "regexManagers": [
+    {
+      "description": "Manage bumping the version of the common bash library",
+      "fileMatch": ["**/scripts/install-binaries.sh"],
+      "matchStrings": [
+        "datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s.*?TAG=(?<currentValue>.*)\\s"
+      ],
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}",
+      "rangeStrategy": "bump",
+      "semanticCommitType": "fix"
+    }
+  ],
   "packageRules": [
     {
       "description": "Group all dependencies into a single PR",
@@ -74,16 +86,6 @@
       "description": "Custom regex required to bump IBM detect secrets",
       "matchPackageNames": ["ibm/detect-secrets"],
       "versioning": "regex:^(?<compatibility>.*)-?(?<major>\\d+)\\.(?<minor>\\d+)\\+ibm\\.(?<patch>\\d+)\\.dss$"
-    },
-    {
-      "description": "Manage bumping the version of the common bash library",
-      "fileMatch": ["**/scripts/install-binaries.sh"],
-      "matchStrings": [
-        "datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s.*?TAG=(?<currentValue>.*)\\s"
-      ],
-      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}",
-      "rangeStrategy": "bump",
-      "semanticCommitType": "fix"
     }
   ]
 }


### PR DESCRIPTION
### Description

The rule to bump the common bash library was in the wrong place. It was under `packageRules` and should have been under `regexManagers`

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [x] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
