### PR TITLE
fix: added retry logic for resource group lookup

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-03-19T15:25:28Z",
+  "generated_at": "2026-05-13T12:31:43Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -146,7 +146,7 @@
         "hashed_secret": "2ed27655a74e3ca714894fe3c62bed0a21ac3b47",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 162,
+        "line_number": 174,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/scripts/iks-api-key-reset/reset_iks_api_key.sh
+++ b/scripts/iks-api-key-reset/reset_iks_api_key.sh
@@ -114,6 +114,9 @@ fetch_data() {
 
 get_resource_group_id() {
     local rg_name="$1"
+    local max_retries=3
+    local retry_delay=10
+    local attempt=1
 
     # Determine the Resource Manager API endpoint
     rc_api_endpoint="${IBMCLOUD_RESOURCE_CONTROLLER_API_ENDPOINT:-"resource-controller.cloud.ibm.com"}"
@@ -125,28 +128,37 @@ get_resource_group_id() {
         RC_URL="https://$rc_api_endpoint/v2/resource_groups?account_id=$ACCOUNT_ID"
     fi
 
-    echo "Looking up resource group ID for name: $rg_name" >&2
+    while [ $attempt -le $max_retries ]; do
+        echo "Looking up resource group ID for name: $rg_name (attempt $attempt/$max_retries)" >&2
 
-    # Fetch resource groups from the API
-    RC_RESPONSE=$(curl -s "$RC_URL" --header "Authorization: Bearer $IAM_TOKEN" --header "Content-Type: application/json")
+        # Fetch resource groups from the API
+        RC_RESPONSE=$(curl -s "$RC_URL" --header "Authorization: Bearer $IAM_TOKEN" --header "Content-Type: application/json")
 
-    ERROR_MESSAGE=$(echo "${RC_RESPONSE}" | jq 'has("errors")')
-    if [[ "${ERROR_MESSAGE}" != false ]]; then
-        echo "${RC_RESPONSE}" | jq '.errors' >&2
-        echo "Could not obtain resource groups" >&2
-        exit 1
-    fi
+        ERROR_MESSAGE=$(echo "${RC_RESPONSE}" | jq 'has("errors")')
+        if [[ "${ERROR_MESSAGE}" != false ]]; then
+            echo "${RC_RESPONSE}" | jq '.errors' >&2
+            echo "Could not obtain resource groups" >&2
+            exit 1
+        fi
 
-    # Extract the resource group ID for the given name
-    RESOURCE_GROUP_ID=$(echo "$RC_RESPONSE" | jq -r --arg name "$rg_name" '.resources[] | select(.name == $name) | .id')
+        # Extract the resource group ID for the given name
+        RESOURCE_GROUP_ID=$(echo "$RC_RESPONSE" | jq -r --arg name "$rg_name" '.resources[] | select(.name == $name) | .id')
 
-    if [[ -z "${RESOURCE_GROUP_ID}" ]] || [[ "${RESOURCE_GROUP_ID}" == "null" ]]; then
-        echo "Resource group with name '$rg_name' not found" >&2
-        exit 1
-    fi
+        if [[ -n "${RESOURCE_GROUP_ID}" ]] && [[ "${RESOURCE_GROUP_ID}" != "null" ]]; then
+            echo "Found resource group ID: $RESOURCE_GROUP_ID" >&2
+            echo "$RESOURCE_GROUP_ID"
+            return 0
+        fi
 
-    echo "Found resource group ID: $RESOURCE_GROUP_ID" >&2
-    echo "$RESOURCE_GROUP_ID"
+        if [ $attempt -lt $max_retries ]; then
+            echo "Resource group with name '$rg_name' not found, retrying in $retry_delay seconds..." >&2
+            sleep $retry_delay
+            ((attempt++))
+        else
+            echo "Resource group with name '$rg_name' not found after $max_retries attempts" >&2
+            exit 1
+        fi
+    done
 }
 
 #######################################################

--- a/scripts/update-source/requirements.txt
+++ b/scripts/update-source/requirements.txt
@@ -1,2 +1,2 @@
 requests==2.33.1
-gitpython==3.1.46
+gitpython==3.1.50


### PR DESCRIPTION
### Description

added retry logic for resource group lookup

Our tests create a unique resource group and then if the reset_api_key script runs, it does a resource group look up using resource controller API and sometimes 5 second sleep delay in tests is not sufficient. So I have added a retry logic for resource group lookup.

<!--- Replace this text with a summary of the changes in this PR. Include why the changes are needed and context about the changes. List required dependencies. If there is a Git issue for the change, please link to it. --->

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [X] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
