### PR TITLE
fix: use full GitHub URLs instead of relative paths in overview links

### DIFF
--- a/module-assets/ci/terraformDocOverview.py
+++ b/module-assets/ci/terraformDocOverview.py
@@ -243,7 +243,7 @@ def get_headings(folder_name, repo_url, module_name):
                         flags=re.IGNORECASE,
                     )
                     module_path = re.sub(regex_pattern, "", path, flags=re.IGNORECASE)
-                    data = f'      <li><a href="./{module_path}">{module_name_display}</a></li>'
+                    data = f'      <li><a href="{repo_url}/tree/main/{module_path}">{module_name_display}</a></li>'
                 elif folder_name == "Deployable Architectures":
                     # for deployable architectures bullet point name is title in solution's README
                     readme_title = terraformDocsUtils.get_readme_title(path)
@@ -252,7 +252,7 @@ def get_headings(folder_name, repo_url, module_name):
                         solution_path = re.sub(
                             regex_pattern, "", path, flags=re.IGNORECASE
                         )
-                        data = f'      <li><a href="./{solution_path}">{title}</a></li>'
+                        data = f'      <li><a href="{repo_url}/tree/main/{solution_path}">{title}</a></li>'
                 else:
                     # for examples bullet point name is title in example's README
                     readme_title = terraformDocsUtils.get_readme_title(path)
@@ -273,7 +273,7 @@ def get_headings(folder_name, repo_url, module_name):
 
                         data = (
                             f"      <li>\n"
-                            f'        <a href="./{example_path}">{title}</a>\n'
+                            f'        <a href="{repo_url}/tree/main/{example_path}">{title}</a>\n'
                             f"        {deploy_button_html}\n"
                             f"      </li>"
                         )
@@ -298,7 +298,7 @@ def add_to_overview(overview, folder_name, repo_url, module_name):
         if folder_name == "Examples" and readme_titles:
             # Use HTML format for Examples section
             display_name = "Submodules" if folder_name == "Modules" else folder_name
-            bullet_point = f'  <li><a href="./{directory_name}">{display_name}</a>'
+            bullet_point = f'  <li><a href="{repo_url}/tree/main/{directory_name}">{display_name}</a>'
             overview.append(bullet_point)
             bullet_point_index = overview.index(bullet_point)
             overview.insert(bullet_point_index + 1, "    <ul>")
@@ -312,7 +312,7 @@ def add_to_overview(overview, folder_name, repo_url, module_name):
             overview.insert(bullet_point_index + 4 + len(readme_titles), "  </li>")
         else:
             display_name = "Submodules" if folder_name == "Modules" else folder_name
-            bullet_point = f'  <li><a href="./{directory_name}">{display_name}</a>'
+            bullet_point = f'  <li><a href="{repo_url}/tree/main/{directory_name}">{display_name}</a>'
             overview.append(bullet_point)
             bullet_point_index = overview.index(bullet_point)
 


### PR DESCRIPTION
### Description
- Changed module, solution, and example path links from relative (./) to full repo URLs

<!--- Replace this text with a summary of the changes in this PR. Include why the changes are needed and context about the changes. List required dependencies. If there is a Git issue for the change, please link to it. --->

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [x] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
