### PR TITLE
feat: updated mysql crn

### DIFF
--- a/common-go-assets/common-permanent-resources.yaml
+++ b/common-go-assets/common-permanent-resources.yaml
@@ -73,8 +73,8 @@ postgresqlPITRVersion: 14
 postgresqlPITRRegion: "us-south"
 
 # mysql instance crn for PITR test
-mysqlPITRCrn: "crn:v1:bluemix:public:databases-for-mysql:us-south:a/abac0df06b644a9cabc6e44f55b3880e:0493008d-1399-440f-ba1a-89bb00e3ac10::"
-mysqlPITRVersion: "8.0"
+mysqlPITRCrn: "crn:v1:bluemix:public:databases-for-mysql:us-south:a/abac0df06b644a9cabc6e44f55b3880e:3cc9df2e-114d-4e2a-8bfb-37606c5ff057::"
+mysqlPITRVersion: "8.4"
 mysqlPITRRegion: "us-south"
 
 # mongoDB instance crn for backup-restore test


### PR DESCRIPTION
### Description

Updated the permanent MySQL instance CRN to the new v8.4 permanent instance CRN 

[Git Issue](https://github.ibm.com/GoldenEye/issues/issues/18598)

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

This PR updates the permanent MySQL instance crn to the new v8.4 permanent instance crn 

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
