### PR TITLE
fix: remove the --global parameter from ensurepath for environments without sudo access

### DIFF
--- a/commonRenovateConfig.json
+++ b/commonRenovateConfig.json
@@ -30,7 +30,7 @@
   "postUpdateOptions": ["gomodTidy", "gomodUpdateImportPaths"],
   "postUpgradeTasks": {
     "description": "The below commands will run on the renovate branch code before pushing it. This ensures correct dependency versions are used for pre-commit hooks. NOTE: currently installing pipx here until the image supports it natively: https://github.com/renovatebot/renovate/discussions/39510",
-    "commands": ["git submodule update --remote --merge && export CUSTOM_DIRECTORY=/tmp && export PIPX_GLOBAL_HOME=/tmp && export PATH=$PATH:/tmp && install-pip pipx && pipx ensurepath --global --force && make dependency-install-darwin-linux && cp /opt/containerbase/tools/golang/*/bin/gofmt /tmp", "export PATH=$PATH:/tmp && pre-commit run --all-files || true"],
+    "commands": ["git submodule update --remote --merge && export CUSTOM_DIRECTORY=/tmp && export PIPX_GLOBAL_HOME=/tmp && export PATH=$PATH:/tmp && install-pip pipx && pipx ensurepath --force && make dependency-install-darwin-linux && cp /opt/containerbase/tools/golang/*/bin/gofmt /tmp", "export PATH=$PATH:/tmp && pre-commit run --all-files || true"],
     "fileFilters": ["**/*.md", "**/*.py", "**/*.toml", "**/*.json", ".secrets.baseline", "**/*.tf", "**/*.go", "go.mod", "go.sum", "common-dev-assets", "armada-csutil", "modules/supertenant-logs-routing-and-icl-agent/helm-charts", "modules/supertenant-logs-routing-agent/helm-charts", "modules/atracker-agent/helm-charts", "modules/logs-routing-module/helm-charts", "modules/prometheus-module/helm-charts"],
     "executionMode": "branch"
   },

--- a/module-assets/ci/install-deps.sh
+++ b/module-assets/ci/install-deps.sh
@@ -209,7 +209,11 @@ fi
 # use --global option to place binaries in /usr/local/bin
 # NB: This will be override by the value of $CUSTOM_DIRECTORY if passed when running this script
 permission_check
-${ARG} pipx ensurepath --global --force
+if [ "${ARG}" = "sudo" ]; then
+  ${ARG} pipx ensurepath --global --force
+else
+  pipx ensurepath --force
+fi
 echo "COMPLETE"
 
 #######################################

--- a/scripts/update-source/requirements.txt
+++ b/scripts/update-source/requirements.txt
@@ -1,2 +1,2 @@
 requests==2.34.2
-gitpython==3.1.51
+gitpython==3.1.55


### PR DESCRIPTION
This [PR](https://github.com/pypa/pipx/pull/1861) changes the `ensurepath --global` update the system PATH configuration instead of root's shell profiles.
since we don't have sudo access to the renovate container we need to remove the --global parameter.

### Description

<!--- Replace this text with a summary of the changes in this PR. Include why the changes are needed and context about the changes. List required dependencies. If there is a Git issue for the change, please link to it. --->

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [X] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
